### PR TITLE
SC-13 # `serverless` command translates project to Serverless structure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,5 @@ install:
 test_script:
   - node --version
   - npm --version
+  - npm cache clean
   - npm test
-cache:
-  - node_modules

--- a/bin/index.js
+++ b/bin/index.js
@@ -23,6 +23,8 @@ const help = `
 const cli = meow({
   help,
   version: true
+}, {
+  string: [ 'out' ]
 })
 
 const command = cli.input[0]
@@ -34,7 +36,7 @@ if (!command) {
 
 let main
 try {
-  main = require(path.join(__dirname, '..', 'commands', command))
+  main = require(path.join(__dirname, '..', 'commands', `${command}.js`))
 } catch (err) {
   console.error(`unknown command: ${command}`)
   console.log(help)

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function (input, flags, logger, options) {
+
+}

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -16,6 +16,7 @@ module.exports = function (input, flags, logger, options) {
   }
 
   return lib.copyRecursive(cwd, out)
-    .then(() => lib.applyTemplate(out))
+    .then(() => lib.applyTemplate(out)) // TODO: eventually unnecessary?
     .then(() => lib.copyWrapper(cwd, out))
+    .then(() => lib.registerFunctions(cwd, out))
 }

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -4,7 +4,7 @@
 bm serve serverless --input . --output /tmp/foobar
 */
 
-const lib = require('../lib/serverless')
+const lib = require('../lib/serverless.js')
 
 module.exports = function (input, flags, logger, options) {
   const cwd = options.cwd
@@ -17,4 +17,5 @@ module.exports = function (input, flags, logger, options) {
 
   return lib.copyRecursive(cwd, out)
     .then(() => lib.applyTemplate(out))
+    .then(() => lib.copyWrapper(cwd, out))
 }

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -16,4 +16,5 @@ module.exports = function (input, flags, logger, options) {
   }
 
   return lib.copyRecursive(cwd, out)
+    .then(() => lib.applyTemplate(out))
 }

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -1,5 +1,19 @@
 'use strict'
 
-module.exports = function (input, flags, logger, options) {
+/**
+bm serve serverless --input . --output /tmp/foobar
+*/
 
+const lib = require('../lib/serverless')
+
+module.exports = function (input, flags, logger, options) {
+  const cwd = options.cwd
+  const out = flags.out
+
+  if (!out) {
+    logger.error(new Error('"--out" is mandatory'))
+    process.exit(1)
+  }
+
+  return lib.copyRecursive(cwd, out)
 }

--- a/example/api/promise/index.js
+++ b/example/api/promise/index.js
@@ -5,7 +5,7 @@ function wait (ms) {
 }
 
 module.exports = function (request) {
-  const ms = parseInt(request.query.ms, 10) || 2000
+  const ms = parseInt(request.url.query.ms, 10) || 2000
 
   return wait(ms)
     .then(() => `waited ${ms} milliseconds!`)

--- a/example/api/request/index.js
+++ b/example/api/request/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function (request) {
+  return request
+}

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const glob = require('glob')
+const pify = require('pify')
+
+function listAPIs (cwd) {
+  return pify(glob)('api/*/index.js', { cwd })
+    .then((matches) => matches.map((match) => match.split('/')[1]))
+}
+
+module.exports = {
+  listAPIs
+}

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -6,6 +6,8 @@ const Boom = require('boom')
 const Hapi = require('hapi')
 const pify = require('pify')
 
+const values = require('./values.js')
+
 function executeAPI (handler, request) {
   return Promise.resolve()
     .then(() => handler(request))
@@ -61,7 +63,7 @@ function startServer (options) {
         .catch((err) => reply(err))
     },
     // HTTP HEAD is automatically provided based on GET
-    method: [ 'DELETE', 'GET', 'OPTION', 'PATCH', 'POST', 'PUT' ],
+    method: values.METHODS,
     path: '/api/{api}' // catch-all
   })
 

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -26,16 +26,40 @@ function getAPI (cwd, name) {
   return api
 }
 
-function simplifyRequest (request) {
+/**
+https://www.w3.org/TR/url-1/#dom-urlutils-protocol
+protocol ends with ':', same as in Node.js 'url' module
+https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+*/
+function protocolFromHeaders (headers) {
+  if (headers['x-forwarded-proto'] === 'https') {
+    return `https:`
+  }
+  if (headers.forwarded && ~headers.forwarded.indexOf('proto=https')) {
+    return `https:`
+  }
+  if (headers['front-end-https'] === 'on') {
+    return `https:`
+  }
+  return 'http:'
+}
+
+// return only the pertinent data from a Hapi Request
+function normaliseHapiRequest (request) {
+  const urlInfo = Object.assign({}, request.url, {
+    host: request.info.host,
+    hostname: request.info.hostname,
+    protocol: protocolFromHeaders(request.headers)
+  })
+  delete urlInfo.auth
+  delete urlInfo.hash
+  delete urlInfo.port
+  delete urlInfo.slashes
   return {
     body: request.payload,
     headers: request.headers,
-    host: request.info.host,
-    hostname: request.info.hostname,
     method: request.method,
-    params: request.params,
-    query: request.query,
-    url: request.url
+    url: urlInfo
   }
 }
 
@@ -56,7 +80,7 @@ function startServer (options) {
         return
       }
 
-      executeAPI(api, simplifyRequest(request))
+      executeAPI(api, normaliseHapiRequest(request))
         .then((result) => {
           reply(null, result || 200)
         })
@@ -85,5 +109,7 @@ function startServer (options) {
 module.exports = {
   executeAPI,
   getAPI,
+  normaliseHapiRequest,
+  protocolFromHeaders,
   startServer
 }

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -47,6 +47,7 @@ function startServer (options) {
       cors: true // development only, not recommended in production
     },
     handler (request, reply) {
+      // TODO: consider sanitising this input
       const api = getAPI(options.cwd, request.params.api)
       if (!api) {
         reply(Boom.notFound())

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,59 +1,24 @@
 'use strict'
 
-const path = require('path')
-
 const Boom = require('boom')
 const Hapi = require('hapi')
 const pify = require('pify')
 
 const values = require('./values.js')
-
-function executeAPI (handler, request) {
-  return Promise.resolve()
-    .then(() => handler(request))
-}
-
-function getAPI (cwd, name) {
-  const apiPath = path.join(cwd, 'api', name, 'index.js')
-  let api
-  try {
-    api = require(apiPath)
-  } catch (err) {
-    // do nothing
-  }
-  // property names in require.cache are absolute paths
-  delete require.cache[apiPath]
-  return api
-}
-
-/**
-https://www.w3.org/TR/url-1/#dom-urlutils-protocol
-protocol ends with ':', same as in Node.js 'url' module
-https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
-*/
-function protocolFromHeaders (headers) {
-  if (headers['x-forwarded-proto'] === 'https') {
-    return `https:`
-  }
-  if (headers.forwarded && ~headers.forwarded.indexOf('proto=https')) {
-    return `https:`
-  }
-  if (headers['front-end-https'] === 'on') {
-    return `https:`
-  }
-  return 'http:'
-}
+const wrapper = require('../scripts/wrapper.js')
 
 // return only the pertinent data from a Hapi Request
 function normaliseHapiRequest (request) {
   const urlInfo = Object.assign({}, request.url, {
     host: request.info.host,
     hostname: request.info.hostname,
-    protocol: protocolFromHeaders(request.headers)
+    protocol: wrapper.protocolFromHeaders(request.headers)
   })
   delete urlInfo.auth
   delete urlInfo.hash
+  delete urlInfo.path
   delete urlInfo.port
+  delete urlInfo.search
   delete urlInfo.slashes
   return {
     body: request.payload,
@@ -74,13 +39,13 @@ function startServer (options) {
     },
     handler (request, reply) {
       // TODO: consider sanitising this input
-      const api = getAPI(options.cwd, request.params.api)
+      const api = wrapper.getAPI(options.cwd, request.params.api)
       if (!api) {
         reply(Boom.notFound())
         return
       }
 
-      executeAPI(api, normaliseHapiRequest(request))
+      wrapper.executeAPI(api, normaliseHapiRequest(request))
         .then((result) => {
           reply(null, result || 200)
         })
@@ -107,9 +72,6 @@ function startServer (options) {
 }
 
 module.exports = {
-  executeAPI,
-  getAPI,
   normaliseHapiRequest,
-  protocolFromHeaders,
   startServer
 }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = {}

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,22 +1,39 @@
 'use strict'
 
+const path = require('path')
+
 const cpr = require('cpr')
 const execa = require('execa')
 const pify = require('pify')
+
+const apis = require('./apis.js')
+
+const CPR_OPTIONS = {
+  confirm: true,
+  deleteFirst: true,
+  overwrite: true
+}
+
+const WRAPPER = path.join(__dirname, '..', 'scripts', 'wrapper.js')
 
 function applyTemplate (cwd) {
   return execa('serverless', [ 'create', '--template', 'aws-nodejs' ], { cwd })
 }
 
 function copyRecursive (source, target) {
-  return pify(cpr)(source, target, {
-    confirm: true,
-    deleteFirst: true,
-    overwrite: true
-  })
+  return pify(cpr)(source, target, CPR_OPTIONS)
+}
+
+function copyWrapper (source, target) {
+  return apis.listAPIs(source)
+    .then((names) => Promise.all(names.map((name) => {
+      const targetWrapper = path.join(target, `${name}.js`)
+      return copyRecursive(WRAPPER, targetWrapper)
+    })))
 }
 
 module.exports = {
   applyTemplate,
-  copyRecursive
+  copyRecursive,
+  copyWrapper
 }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,12 +1,15 @@
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 
 const cpr = require('cpr')
 const execa = require('execa')
 const pify = require('pify')
+const yaml = require('js-yaml')
 
 const apis = require('./apis.js')
+const values = require('./values.js')
 
 const CPR_OPTIONS = {
   confirm: true,
@@ -32,8 +35,39 @@ function copyWrapper (source, target) {
     })))
 }
 
+function registerFunctions (source, target) {
+  const configPath = path.join(target, 'serverless.yml')
+  return pify(fs.readFile)(configPath, 'utf8')
+    .then((content) => Promise.all([
+      apis.listAPIs(source),
+      yaml.safeLoad(content)
+    ]))
+    .then((results) => {
+      const names = results[0]
+      const config = results[1]
+
+      config.functions = names.reduce((functions, name) => {
+        functions[name] = {
+          events: values.METHODS.map((METHOD) => ({
+            http: `${METHOD} ${name}`
+          })),
+          handler: `${name}.handler`
+        }
+        return functions
+      }, {})
+
+      return config
+    })
+    .then((config) => pify(fs.writeFile)(
+      configPath,
+      yaml.safeDump(config),
+      'utf8')
+    )
+}
+
 module.exports = {
   applyTemplate,
   copyRecursive,
-  copyWrapper
+  copyWrapper,
+  registerFunctions
 }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,15 +1,22 @@
 'use strict'
 
 const cpr = require('cpr')
+const execa = require('execa')
 const pify = require('pify')
+
+function applyTemplate (cwd) {
+  return execa('serverless', [ 'create', '--template', 'aws-nodejs' ], { cwd })
+}
 
 function copyRecursive (source, target) {
   return pify(cpr)(source, target, {
     confirm: true,
+    deleteFirst: true,
     overwrite: true
   })
 }
 
 module.exports = {
+  applyTemplate,
   copyRecursive
 }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -65,6 +65,8 @@ function registerFunctions (source, target) {
     )
 }
 
+// TODO: configure CORS
+
 module.exports = {
   applyTemplate,
   copyRecursive,

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,3 +1,15 @@
 'use strict'
 
-module.exports = {}
+const cpr = require('cpr')
+const pify = require('pify')
+
+function copyRecursive (source, target) {
+  return pify(cpr)(source, target, {
+    confirm: true,
+    overwrite: true
+  })
+}
+
+module.exports = {
+  copyRecursive
+}

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const METHODS = [ 'DELETE', 'GET', 'OPTION', 'PATCH', 'POST', 'PUT' ]
+const METHODS = [ 'DELETE', 'GET', 'OPTIONS', 'PATCH', 'POST', 'PUT' ]
 
 module.exports = {
   METHODS

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const METHODS = [ 'DELETE', 'GET', 'OPTION', 'PATCH', 'POST', 'PUT' ]
+
+module.exports = {
+  METHODS
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "boom": "4.1.0",
+    "cpr": "2.0.0",
     "good": "7.0.2",
     "good-console": "6.1.2",
     "hapi": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "files": [
     "bin",
     "commands",
-    "lib"
+    "lib",
+    "scripts"
   ],
   "homepage": "https://github.com/blinkmobile/server-cli#readme",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "boom": "4.1.0",
     "cpr": "2.0.0",
+    "execa": "0.4.0",
     "good": "7.0.2",
     "good-console": "6.1.2",
     "hapi": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "good": "7.0.2",
     "good-console": "6.1.2",
     "hapi": "15.1.1",
+    "js-yaml": "3.6.1",
     "meow": "3.7.0",
     "pify": "2.3.0",
     "update-notifier": "1.0.2"

--- a/scripts/wrapper.js
+++ b/scripts/wrapper.js
@@ -1,3 +1,106 @@
 'use strict'
 
-module.exports.handler = function (event, context, cb) {}
+const path = require('path')
+
+/**
+This is a single-file wrapper script for use at endpoint runtime.
+This means that all helper functions that are used need to be defined here,
+even if they are used by other files during deploy / test time.
+*/
+
+function executeAPI (handler, request) {
+  return Promise.resolve()
+    .then(() => handler(request))
+}
+
+function getAPI (cwd, name) {
+  const apiPath = path.join(cwd, 'api', name, 'index.js')
+  let api
+  try {
+    api = require(apiPath)
+  } catch (err) {
+    // do nothing
+  }
+  // property names in require.cache are absolute paths
+  delete require.cache[apiPath]
+  return api
+}
+
+// assume that this file has been copied and renamed as appropriate
+function getAPIName () {
+  return path.basename(__filename, '.js')
+}
+
+function keysToLowerCase (object) {
+  return Object.keys(object).reduce((result, key) => {
+    result[key.toLowerCase()] = object[key]
+    return result
+  }, {})
+}
+
+function normaliseMethod (method) {
+  return method.toLowerCase()
+}
+
+/**
+https://www.w3.org/TR/url-1/#dom-urlutils-protocol
+protocol ends with ':', same as in Node.js 'url' module
+https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+*/
+function protocolFromHeaders (headers) {
+  if (headers['x-forwarded-proto'] === 'https') {
+    return `https:`
+  }
+  if (headers.forwarded && ~headers.forwarded.indexOf('proto=https')) {
+    return `https:`
+  }
+  if (headers['front-end-https'] === 'on') {
+    return `https:`
+  }
+  return 'http:'
+}
+
+// return only the pertinent data from a API Gateway + Lambda event
+function normaliseLambdaRequest (request) {
+  const headers = keysToLowerCase(request.headers)
+  return {
+    body: request.body,
+    headers,
+    method: normaliseMethod(request.method),
+    url: {
+      host: headers.host,
+      hostname: headers.host,
+      pathname: `/api/${getAPIName()}`,
+      protocol: protocolFromHeaders(headers),
+      query: request.query
+    }
+  }
+}
+
+function handler (event, context, cb) {
+  // TODO: extract error code from Boom-compatible errors
+  // TODO: error handling needs to match Serverless' APIG error templates
+  const api = getAPI(__dirname, getAPIName())
+  if (!api) {
+    cb(new Error(500))
+    return
+  }
+
+  // TODO: transparently implement HEAD
+
+  executeAPI(api, normaliseLambdaRequest(event))
+    .then((result) => {
+      cb(null, result || 200)
+    })
+    .catch((err) => cb(err))
+}
+
+module.exports = {
+  executeAPI,
+  getAPI,
+  handler,
+  keysToLowerCase,
+  normaliseMethod,
+  normaliseLambdaRequest,
+  protocolFromHeaders
+}

--- a/scripts/wrapper.js
+++ b/scripts/wrapper.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports.handler = function (event, context, cb) {}

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const test = require('ava')
+
+const wrapper = require('../scripts/wrapper.js')
+
+test('exports a "handler" function', (t) => {
+  t.is(typeof wrapper.handler, 'function')
+})


### PR DESCRIPTION
### Added
- SC-13: `bm server serverless --out <targetdir>` is a new command
  - undocumented, does not appear in `--help`
  - translates the project in the current working directory to the target output directory
  - uses a one-size-fits-all wrapper script and strict conventions to facilitate conversion
### Code Review Notes
- probably worth reviewing these one commit at a time
- known incomplete work to be tackled in future:
  - [ ] custom URLs
  - [ ] thorough test coverage (improved significantly in #6)
  - [ ] friendlier instructions and error messages
  - [ ] CORS
  - [ ] HTTP response headers
  - [ ] HTTP status codes / errors
  - [x] alternative `module.exports` conventions for HTTP methods (see #6)
  - [ ] native Node.js modules (compile for Linux)
  - [ ] project permissions managements
  - [ ] cloud-hosted proxy endpoint (with above permissions)
