### PR TITLE
SC-18 # Allow customers to configure CORS headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Usage: blinkm server <command> <project_path>
 
 Commands:
   serve                   => start a local development server using local API files
+    --port <port>         => sets the port to use for server
   info                    => displays project information
   scope                   => displays the current scope
     --project <project>   => sets the project id
@@ -57,13 +58,29 @@ CORS can be configured in a `json` file that is pointed at from `package.json:ma
 
 ### bm-server.json
 
+By setting cors to `false`, Cross-Origin resource sharing will not be allowed. **This is the default behaviour**
+
+```json
+{
+  "cors": false
+}
+```
+
+By setting cors to `true`, defaults below will be used.
+
+```json
+{
+  "cors": true
+}
+```
+
+**Note:** If any properties are omitted, they will default to the example below.
+
 ```json
 {
   "cors": {
     "origins": [
-      "http://your.first.client",
-      "http://your.second.client",
-      "http://your.third.client"
+      "*"
     ],
     "headers": [
       "Accept",
@@ -73,11 +90,13 @@ CORS can be configured in a `json` file that is pointed at from `package.json:ma
       "X-Amz-Date",
       "X-Amz-Security-Token",
       "X-Api-Key"
-    ]
+    ],
+    "exposedHeaders": [
+      "Server-Authorization",
+      "WWW-Authenticate"
+    ],
+    "credentials": false,
+    "maxAge": 86400 // in seconds = 1 day
   }
 }
 ```
-
-### Allowed Headers
-
-Headers can be omitted and will default to the headers in the example above.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,57 @@ Commands:
     --project <project>   => sets the project id
     --region <region>     => optionally sets the region
 ```
+
+## CORS Configuration
+
+[Cross-Origin Resource Sharing](https://www.w3.org/TR/cors/) protocol allows browsers to make cross-origin API calls.
+CORS is required by web applications running inside a browser which are loaded from a different domain than the API server.
+
+CORS can be configured in a `json` file that is pointed at from `package.json:main` in the root of your project directory e.g.
+
+### Directory Structure
+
+```
+|-- project-root
+|   |-- bm-server.json
+|   |-- package.json
+|   |-- helloworld
+|   |   |-- index.js
+```
+
+### package.json
+
+```json
+{
+  "name": "example",
+  "version": "0.0.1",
+  "main": "bm-server.json",
+}
+```
+
+### bm-server.json
+
+```json
+{
+  "cors": {
+    "origins": [
+      "http://your.first.client",
+      "http://your.second.client",
+      "http://your.third.client"
+    ],
+    "headers": [
+      "Accept",
+      "Authorization",
+      "Content-Type",
+      "If-None-Match",
+      "X-Amz-Date",
+      "X-Amz-Security-Token",
+      "X-Api-Key"
+    ]
+  }
+}
+```
+
+### Allowed Headers
+
+Headers can be omitted and will default to the headers in the example above.

--- a/bin/index.js
+++ b/bin/index.js
@@ -51,7 +51,7 @@ try {
   main = require(path.join(__dirname, '..', 'commands', `${command}.js`))
 } catch (err) {
   console.error(chalk.red(`
-Unknown command: ${command}`, err))
+Unknown command: ${command}`))
   cli.showHelp(1)
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,7 @@ Usage: blinkm server <command> <project_path>
 
 Commands:
   serve                   => start a local development server using local API files
+    --port <port>         => sets the port to use for server
   info                    => displays project information
   scope                   => displays the current scope
     --project <project>   => sets the project id
@@ -34,6 +35,7 @@ const cli = meow({
   },
   string: [
     'out',
+    'port',
     'stage'
   ]
 })
@@ -49,7 +51,7 @@ try {
   main = require(path.join(__dirname, '..', 'commands', `${command}.js`))
 } catch (err) {
   console.error(chalk.red(`
-Unknown command: ${command}`))
+Unknown command: ${command}`, err))
   cli.showHelp(1)
 }
 

--- a/commands/info.js
+++ b/commands/info.js
@@ -1,11 +1,13 @@
 'use strict'
 
+const displayCors = require('../lib/cors/display.js')
 const displayRoutes = require('../lib/routes/display.js')
 const scope = require('../lib/scope.js')
 
 module.exports = function (input, flags, logger, options) {
   const tasks = [
     () => scope.display(logger, options.cwd),
+    () => displayCors(logger, options.cwd),
     () => displayRoutes(logger, options.cwd)
   ]
   // Catch all errors and let all tasks run before

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -3,14 +3,17 @@
 const path = require('path')
 
 const serve = require('../lib/serve.js')
+const readCors = require('../lib/cors/read.js')
 
 module.exports = function (input, flags, logger, options) {
   const cwd = path.resolve(options.cwd)
   const example = path.join(cwd, 'helloworld', 'index.js')
-  return serve.startServer({
-    cwd,
-    port: 3000
-  })
+  return readCors(cwd)
+    .then((cors) => serve.startServer({
+      cors,
+      cwd,
+      port: 3000
+    })
     .then((server) => logger.log(`
 HTTP service for local development is running at port ${server.info.port}
 
@@ -22,5 +25,5 @@ HTTP API files should be in sub-folders within the directory above E.g:
 
 Create new HTTP APIs, rename, update, or delete them at any time
 Your changes automatically take effect on the next request
-`))
+`)))
 }

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -4,16 +4,19 @@ const path = require('path')
 
 const chalk = require('chalk')
 
+const readCors = require('../lib/cors/read.js')
 const serve = require('../lib/serve.js')
 
 module.exports = function (input, flags, logger, options) {
   const cwd = path.resolve(options.cwd)
   const example = path.join('helloworld', 'index.js')
-  return serve.startServer({
-    cwd,
-    port: flags.port || 3000
-  })
-  .then((server) => logger.log(`
+  return readCors(cwd)
+    .then((cors) => serve.startServer({
+      cors,
+      cwd,
+      port: flags.port || 3000
+    })
+    .then((server) => logger.log(`
 HTTP service for local development is available from:
   ${server.info.uri}
 
@@ -27,5 +30,5 @@ Create new HTTP APIs, rename, update, or delete them at any time.
 Your changes automatically take effect on the next request
 
 ${chalk.yellow('Hit CTRL-C to stop the service')}
-`))
+`)))
 }

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -2,28 +2,30 @@
 
 const path = require('path')
 
+const chalk = require('chalk')
+
 const serve = require('../lib/serve.js')
-const readCors = require('../lib/cors/read.js')
 
 module.exports = function (input, flags, logger, options) {
   const cwd = path.resolve(options.cwd)
-  const example = path.join(cwd, 'helloworld', 'index.js')
-  return readCors(cwd)
-    .then((cors) => serve.startServer({
-      cors,
-      cwd,
-      port: 3000
-    })
-    .then((server) => logger.log(`
-HTTP service for local development is running at port ${server.info.port}
+  const example = path.join('helloworld', 'index.js')
+  return serve.startServer({
+    cwd,
+    port: flags.port || 3000
+  })
+  .then((server) => logger.log(`
+HTTP service for local development is available from:
+  ${server.info.uri}
 
 Your current directory "." is:
   ${cwd}
 
 HTTP API files should be in sub-folders within the directory above E.g:
-  ${example}
+  ${example} -> ${server.info.uri}/helloworld
 
-Create new HTTP APIs, rename, update, or delete them at any time
+Create new HTTP APIs, rename, update, or delete them at any time.
 Your changes automatically take effect on the next request
-`)))
+
+${chalk.yellow('Hit CTRL-C to stop the service')}
+`))
 }

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -18,6 +18,6 @@ module.exports = function (input, flags, logger, options) {
   return lib.copyProject(cwd, out)
     .then(() => lib.applyTemplate(out)) // TODO: eventually unnecessary?
     .then(() => lib.copyWrapper(out))
-    .then(() => lib.copyRoutes(out, stage))
+    .then(() => lib.copyConfiguration(out, stage))
     .then(() => lib.registerFunctions(out, stage))
 }

--- a/dist/wrapper.js
+++ b/dist/wrapper.js
@@ -1913,54 +1913,61 @@ const wrapper = require('../lib/wrapper.js')
 // return only the pertinent data from a API Gateway + Lambda event
 function normaliseLambdaRequest (request) {
   const headers = wrapper.keysToLowerCase(request.headers)
+  let body = request.body
+  try {
+    body = JSON.parse(body)
+  } catch (e) {
+    // Do nothing...
+  }
   return {
-    body: request.body,
+    body,
     headers,
-    method: wrapper.normaliseMethod(request.method),
+    method: wrapper.normaliseMethod(request.httpMethod),
     url: {
       host: headers.host,
       hostname: headers.host,
-      params: request.path,
+      params: request.pathParameters || {},
+      pathname: request.path,
       protocol: wrapper.protocolFromHeaders(headers),
-      query: request.query
+      query: request.queryStringParameters || {}
     }
   }
 }
 
+function finish (cb, body, statusCode) {
+  cb(null, {
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    statusCode: statusCode
+  })
+}
+
 function handler (event, context, cb) {
-  // TODO: extract error code from Boom-compatible errors
-  // TODO: error handling needs to match Serverless' APIG error templates
   const routesPath = path.join(__dirname, 'routes.json')
   return loadJsonFile(routesPath, 'utf8')
     .then((routeConfigs) => {
       const request = normaliseLambdaRequest(event)
-      const routeConfig = routeConfigs.find((routeConfig) => routeConfig.functionName === context.functionName)
+      const routeConfig = routeConfigs.find((routeConfig) => routeConfig.route === event.resource)
       if (!routeConfig) {
-        return Promise.reject(new Error('[500] Internal Server Error'))
+        return finish(cb, 'Internal Server Error', 500)
       }
-      request.url.pathname = routeConfig.route
-      // Replace params in route to get pathname
-      Object.keys(request.url.params).forEach((key) => {
-        const val = request.url.params[key]
-        request.url.pathname = request.url.pathname.replace(`{${key}}`, val)
-      })
-      const handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
 
+      const handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
       if (!handler) {
-        return Promise.reject(new Error('[500] Internal Server Error'))
+        return finish(cb, 'Internal Server Error', 500)
       }
       if (typeof handler !== 'function') {
-        return Promise.reject(new Error('[501] Not Implemented'))
+        return finish(cb, 'Method Not Implemented', 405)
       }
 
-      // TODO: transparently implement HEAD
-
       return handlers.executeHandler(handler, request)
-        .then((result) => {
-          cb(null, result || 200)
-        })
+        // TODO: Allow for customer to set there own statusCode and headers (including CORS)
+        .then((result) => finish(cb, result, 200))
     })
-    .catch((err) => cb(err))
+    // TODO: extract error code from Boom-compatible errors
+    .catch((error) => finish(cb, error && error.message ? error.message : (error || 'Internal Server Error'), 500))
 }
 
 module.exports = {

--- a/dist/wrapper.js
+++ b/dist/wrapper.js
@@ -1934,37 +1934,70 @@ function normaliseLambdaRequest (request) {
   }
 }
 
-function finish (cb, body, statusCode) {
+function finish (cb, body, statusCode, corsHeaders) {
   cb(null, {
     body: JSON.stringify(body),
-    headers: {
+    headers: Object.assign({
       'Content-Type': 'application/json'
-    },
+    }, corsHeaders),
     statusCode: statusCode
   })
 }
 
 function handler (event, context, cb) {
-  const routesPath = path.join(__dirname, 'routes.json')
-  return loadJsonFile(routesPath, 'utf8')
-    .then((routeConfigs) => {
-      const request = normaliseLambdaRequest(event)
-      const routeConfig = routeConfigs.find((routeConfig) => routeConfig.route === event.resource)
+  const request = normaliseLambdaRequest(event)
+  const configPath = path.join(__dirname, 'bm-server.json')
+  return loadJsonFile(configPath, 'utf8')
+    .then((config) => {
+      // Get handler module based on route
+      const routeConfig = config.routes.find((routeConfig) => routeConfig.route === event.resource)
       if (!routeConfig) {
         return finish(cb, 'Internal Server Error', 500)
       }
 
-      const handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
+      let handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
       if (!handler) {
         return finish(cb, 'Internal Server Error', 500)
       }
       if (typeof handler !== 'function') {
-        return finish(cb, 'Method Not Implemented', 405)
+        if (request.method === 'options') {
+          // If we couldnt find the options function we can just finish
+          // as we have created our own implementation of CORS
+          handler = () => {}
+        } else {
+          return finish(cb, 'Method Not Implemented', 405)
+        }
+      }
+
+      // Check for browser requests and apply CORS if required
+      let corsHeaders = {}
+      if (request.headers.origin) {
+        if (!config.cors) {
+          // No cors, we will return 405 result and let browser handler error
+          return finish(cb, 'Method Not Implemented', 405)
+        }
+        if (!config.cors.origins.some((origin) => origin === '*' || origin === request.headers.origin)) {
+          // Invalid origin, we will return 200 result and let browser handler error
+          return finish(cb, null, 200)
+        }
+        // Headers for all cross origin requests
+        corsHeaders['Access-Control-Allow-Origin'] = request.headers.origin
+        corsHeaders['Access-Control-Expose-Headers'] = config.cors.exposedHeaders.join(',')
+        // Headers for OPTIONS cross origin requests
+        if (request.method === 'options' && request.headers['access-control-request-method']) {
+          corsHeaders['Access-Control-Allow-Headers'] = config.cors.headers.join(',')
+          corsHeaders['Access-Control-Allow-Methods'] = request.headers['access-control-request-method']
+          corsHeaders['Access-Control-Max-Age'] = config.cors.maxAge
+        }
+        // Only set credentials header if truthy
+        if (config.cors.credentials) {
+          corsHeaders['Access-Control-Allow-Credentials'] = true
+        }
       }
 
       return handlers.executeHandler(handler, request)
-        // TODO: Allow for customer to set there own statusCode and headers (including CORS)
-        .then((result) => finish(cb, result, 200))
+        // TODO: Allow for customer to set there own statusCode and headers
+        .then((result) => finish(cb, result, 200, corsHeaders))
     })
     // TODO: extract error code from Boom-compatible errors
     .catch((error) => finish(cb, error && error.message ? error.message : (error || 'Internal Server Error'), 500))

--- a/lib/cors/display.js
+++ b/lib/cors/display.js
@@ -6,36 +6,49 @@ const chalk = require('chalk')
 
 const readCors = require('./read.js')
 const validateCors = require('./validate.js')
-const values = require('../values.js')
 
 function displayCors (
   logger /* : any */,
   cwd /* : string */
 ) /* : Promise<void> */ {
   return readCors(cwd)
-    .then((cors) => validateCors(cors))
     .then((cors) => {
-      const table = new Table()
-      table.push([{
-        content: chalk.bold('Cors Configuration'),
-        hAlign: 'center',
-        colSpan: 2
-      }])
+      if (!cors) {
+        return
+      }
+      return validateCors(cors)
+        .then((mergedCors) => {
+          const table = new Table()
+          table.push(
+            [{
+              content: chalk.bold('Cors Configuration'),
+              hAlign: 'center',
+              colSpan: 2
+            }],
+            [
+              chalk.grey('Origins'),
+              mergedCors.origins.sort().join('\n')
+            ],
+            [
+              chalk.grey('Allowed Headers'),
+              mergedCors.headers.sort().join('\n')
+            ],
+            [
+              chalk.grey('Exposed Headers'),
+              mergedCors.exposedHeaders.sort().join('\n')
+            ],
+            [
+              chalk.grey('Max Age'),
+              mergedCors.maxAge
+            ],
+            [
+              chalk.grey('Allow Credentials'),
+              mergedCors.credentials
+            ]
+          )
 
-      const headings = [
-        'Origins',
-        'Headers' + (cors.headers ? '' : ' (defaults)')
-      ]
-      table.push(headings.map((heading) => (chalk.grey(heading))))
-
-      const tableRow = [
-        cors.origins,
-        (cors.headers || values.DEFAULT_HEADERS)
-      ]
-      const ordered = tableRow.map((section) => section.sort().join('\n'))
-      table.push(ordered)
-
-      logger.log(table.toString())
+          logger.log(table.toString())
+        })
     })
 }
 

--- a/lib/cors/display.js
+++ b/lib/cors/display.js
@@ -1,0 +1,42 @@
+/* @flow */
+'use strict'
+
+const Table = require('cli-table2')
+const chalk = require('chalk')
+
+const readCors = require('./read.js')
+const validateCors = require('./validate.js')
+const values = require('../values.js')
+
+function displayCors (
+  logger /* : any */,
+  cwd /* : string */
+) /* : Promise<void> */ {
+  return readCors(cwd)
+    .then((cors) => validateCors(cors))
+    .then((cors) => {
+      const table = new Table()
+      table.push([{
+        content: chalk.bold('Cors Configuration'),
+        hAlign: 'center',
+        colSpan: 2
+      }])
+
+      const headings = [
+        'Origins',
+        'Headers' + (cors.headers ? '' : ' (defaults)')
+      ]
+      table.push(headings.map((heading) => (chalk.grey(heading))))
+
+      const tableRow = [
+        cors.origins,
+        (cors.headers || values.DEFAULT_HEADERS)
+      ]
+      const ordered = tableRow.map((section) => section.sort().join('\n'))
+      table.push(ordered)
+
+      logger.log(table.toString())
+    })
+}
+
+module.exports = displayCors

--- a/lib/cors/read.js
+++ b/lib/cors/read.js
@@ -1,0 +1,20 @@
+/* @flow */
+'use strict'
+
+const configuation = require('../configuration.js')
+
+/* ::
+export type CorsConfiguration = {
+  origins: Array<string>,
+  headers: Array<string> | void
+}
+*/
+
+function readCors (
+  cwd /* : string */
+) /* : Promise<CorsConfiguration> */ {
+  return configuation.read(cwd)
+    .then((config) => config.cors || {})
+}
+
+module.exports = readCors

--- a/lib/cors/read.js
+++ b/lib/cors/read.js
@@ -1,20 +1,38 @@
 /* @flow */
 'use strict'
 
-const configuation = require('../configuration.js')
-
 /* ::
 export type CorsConfiguration = {
-  origins: Array<string>,
-  headers: Array<string> | void
+  credentials: boolean,
+  exposedHeaders: Array<string>,
+  headers: Array<string>,
+  maxAge: number,
+  origins: Array<string>
 }
 */
 
+const configuation = require('../configuration.js')
+const values = require('../values.js')
+
 function readCors (
   cwd /* : string */
-) /* : Promise<CorsConfiguration> */ {
+) /* : Promise<CorsConfiguration | false> */ {
   return configuation.read(cwd)
-    .then((config) => config.cors || {})
+    .then((config) => {
+      // Want to support two options here:
+      // 1. Falsey to disable CORS
+      if (!config.cors) {
+        return false
+      }
+      // 2. Truthy to use default CORS and merge in any custom stuff
+      return Object.assign({
+        credentials: values.DEFAULT_CORS.CREDENTIALS,
+        exposedHeaders: values.DEFAULT_CORS.EXPOSED_HEADERS,
+        headers: values.DEFAULT_CORS.HEADERS,
+        maxAge: values.DEFAULT_CORS.MAX_AGE,
+        origins: values.DEFAULT_CORS.ORIGINS
+      }, config.cors)
+    })
 }
 
 module.exports = readCors

--- a/lib/cors/validate.js
+++ b/lib/cors/validate.js
@@ -1,0 +1,39 @@
+/* @flow */
+'use strict'
+
+const validUrl = require('valid-url')
+
+/* ::
+import type {CorsConfiguration} from './read.js'
+*/
+
+const HELP = ', see documentation for information on how to configure cors.'
+
+function validateCors (
+  cors /* : CorsConfiguration */
+) /* : Promise<CorsConfiguration> */ {
+  if (!cors) {
+    return Promise.reject(new Error('Must specify cors configuration' + HELP))
+  }
+  if (!cors.origins || !Array.isArray(cors.origins) || !cors.origins.length) {
+    return Promise.reject(new Error('Must specify at least a single allowable origin in cors configuration' + HELP))
+  }
+  if (cors.origins.some((origin) => origin === '*')) {
+    return Promise.reject(new Error('Cannot specify all origins as allowable in cors configuration i.e. "*"' + HELP))
+  }
+  const invalidOrigins = cors.origins.reduce((invalidOrigins, origin) => {
+    if (!validUrl.isWebUri(origin)) {
+      invalidOrigins.push(origin)
+    }
+    return invalidOrigins
+  }, [])
+  if (invalidOrigins.length) {
+    return Promise.reject(new Error('The following origins in cors configuration are not valid: ' + invalidOrigins.join(', ')))
+  }
+  if (cors.headers && !Array.isArray(cors.headers)) {
+    return Promise.reject(new Error('Invalid headers in cors configuration' + HELP))
+  }
+  return Promise.resolve(cors)
+}
+
+module.exports = validateCors

--- a/lib/cors/validate.js
+++ b/lib/cors/validate.js
@@ -2,6 +2,8 @@
 'use strict'
 
 const validUrl = require('valid-url')
+const isBoolean = require('lodash.isboolean')
+const isNumber = require('lodash.isnumber')
 
 /* ::
 import type {CorsConfiguration} from './read.js'
@@ -15,14 +17,12 @@ function validateCors (
   if (!cors) {
     return Promise.reject(new Error('Must specify cors configuration' + HELP))
   }
+  // Origins
   if (!cors.origins || !Array.isArray(cors.origins) || !cors.origins.length) {
     return Promise.reject(new Error('Must specify at least a single allowable origin in cors configuration' + HELP))
   }
-  if (cors.origins.some((origin) => origin === '*')) {
-    return Promise.reject(new Error('Cannot specify all origins as allowable in cors configuration i.e. "*"' + HELP))
-  }
   const invalidOrigins = cors.origins.reduce((invalidOrigins, origin) => {
-    if (!validUrl.isWebUri(origin)) {
+    if (origin !== '*' && !validUrl.isWebUri(origin)) {
       invalidOrigins.push(origin)
     }
     return invalidOrigins
@@ -30,8 +30,21 @@ function validateCors (
   if (invalidOrigins.length) {
     return Promise.reject(new Error('The following origins in cors configuration are not valid: ' + invalidOrigins.join(', ')))
   }
+  // Headers
   if (cors.headers && !Array.isArray(cors.headers)) {
-    return Promise.reject(new Error('Invalid headers in cors configuration' + HELP))
+    return Promise.reject(new Error('Headers must be an array of strings in cors configuration' + HELP))
+  }
+  // Exposed Headers
+  if (cors.exposedHeaders && !Array.isArray(cors.exposedHeaders)) {
+    return Promise.reject(new Error('Exposed headers must be an array of strings in cors configuration' + HELP))
+  }
+  // Max Age
+  if (!isNumber(cors.maxAge)) {
+    return Promise.reject(new Error('Max age must be a number in cors configuration' + HELP))
+  }
+  // Credentials
+  if (!isBoolean(cors.credentials)) {
+    return Promise.reject(new Error('Credentials must be a boolean in cors configuration' + HELP))
   }
   return Promise.resolve(cors)
 }

--- a/lib/routes/display.js
+++ b/lib/routes/display.js
@@ -46,7 +46,7 @@ function displayRoutes (
         .then(() => {
           logger.log(table.toString())
           if (totalErrors) {
-            return Promise.reject(new Error(`${totalErrors} of ${routeConfigs.length} route configurations are not valid.`))
+            return Promise.reject(new Error(`${totalErrors} of ${routeConfigs.length} route configurations are invalid.`))
           }
         })
     })

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -9,6 +9,16 @@ const handlers = require('./handlers.js')
 const values = require('./values.js')
 const wrapper = require('./wrapper.js')
 
+function normaliseHapiCors (cors) {
+  return {
+    credentials: cors.credentials,
+    exposedHeaders: cors.exposedHeaders,
+    headers: cors.headers,
+    maxAge: cors.maxAge,
+    origin: cors.origins
+  }
+}
+
 // return only the pertinent data from a Hapi Request
 function normaliseHapiRequest (request, params) {
   const urlInfo = Object.assign({}, request.url, {
@@ -37,16 +47,9 @@ function startServer (options) {
   const server = new Hapi.Server()
   server.connection({ port: options.port })
 
-  let cors = true // development only, not recommended in production
-  if (options.cors && options.cors.origins) {
-    cors = {
-      origin: options.cors.origins,
-      headers: options.cors.headers || values.DEFAULT_HEADERS
-    }
-  }
   server.route({
     config: {
-      cors
+      cors: options.cors ? normaliseHapiCors(options.cors) : false
     },
     handler (request, reply) {
       // TODO: consider sanitising this input
@@ -83,7 +86,7 @@ function startServer (options) {
         .catch((err) => reply(err))
     },
     // HTTP HEAD is automatically provided based on GET
-    method: values.METHODS,
+    method: values.METHODS.filter((method) => method !== 'OPTIONS'),
     path: '/{route*}' // catch-all
   })
 
@@ -103,6 +106,7 @@ function startServer (options) {
 }
 
 module.exports = {
+  normaliseHapiCors,
   normaliseHapiRequest,
   startServer
 }

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -37,9 +37,16 @@ function startServer (options) {
   const server = new Hapi.Server()
   server.connection({ port: options.port })
 
+  let cors = true // development only, not recommended in production
+  if (options.cors && options.cors.origins) {
+    cors = {
+      origin: options.cors.origins,
+      headers: options.cors.headers || values.DEFAULT_HEADERS
+    }
+  }
   server.route({
     config: {
-      cors: true // development only, not recommended in production
+      cors
     },
     handler (request, reply) {
       // TODO: consider sanitising this input

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -11,6 +11,7 @@ const yaml = require('js-yaml')
 const writeJsonFile = require('write-json-file')
 
 const nonAlphaNumericToDashes = require('./utils/non-alpha-numeric-to-dashes.js')
+const readCors = require('./cors/read.js')
 const readRoutes = require('./routes/read.js')
 const scope = require('./scope.js')
 const values = require('./values.js')
@@ -97,23 +98,37 @@ function registerFunctions (
     .then((content) => Promise.all([
       readRoutes(projectPath),
       yaml.safeLoad(content),
-      scope.read(projectPath)
+      scope.read(projectPath),
+      readCors(projectPath)
     ]))
     .then((results) => {
       const routeConfigs = results[0]
       const config = results[1]
       const cfg = results[2]
+      const cors = results[3]
 
       config.service = nonAlphaNumericToDashes(cfg.project)
       config.provider.region = cfg.region
       config.provider.stage = stage
+      if (cors && cors.origins) {
+        config.custom = {
+          cors: {
+            origins: cors.origins,
+            headers: cors.headers || values.DEFAULT_HEADERS
+          }
+        }
+      }
       config.functions = routeConfigs.reduce((functions, routeConfig, index) => {
         // The route must not start with a leading '/'
         const route = routeConfig.route.substr(1)
         const functionName = getFunctionName(index.toString(), stage, cfg.project)
         functions[index] = {
           events: values.METHODS.map((METHOD) => ({
-            http: `${METHOD} ${route}`
+            http: {
+              cors: cors && cors.origins ? '${self:custom.cors}' : false, // eslint-disable-line no-template-curly-in-string
+              method: METHOD.toLowerCase(),
+              path: route
+            }
           })),
           handler: `${HANDLER}.handler`,
           name: functionName,

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,6 +1,15 @@
 /* @flow */
 'use strict'
 
+/* ::
+import type {CorsConfiguration} from './cors/read.js'
+type ServerlessRouteConfiguration = {
+  functionName: string,
+  module: string,
+  route: string
+}
+*/
+
 const fs = require('fs')
 const path = require('path')
 
@@ -14,6 +23,7 @@ const nonAlphaNumericToDashes = require('./utils/non-alpha-numeric-to-dashes.js'
 const readCors = require('./cors/read.js')
 const readRoutes = require('./routes/read.js')
 const scope = require('./scope.js')
+const validateCors = require('./cors/validate.js')
 const values = require('./values.js')
 
 const CPR_OPTIONS = {
@@ -28,6 +38,21 @@ function applyTemplate (
   cwd /* : string */
 ) /* : Promise<void> */ {
   return execa('serverless', [ 'create', '--template', 'aws-nodejs' ], { cwd })
+}
+
+function copyConfiguration (
+  target /* : string */,
+  stage /* : string */
+) /* : Promise<void> */ {
+  const configPath = path.join(target, 'bm-server.json')
+  return Promise.all([
+    getCors(target),
+    getRoutes(target, stage)
+  ])
+    .then((results) => writeJsonFile(configPath, {
+      cors: results[0],
+      routes: results[1]
+    }))
 }
 
 function copyProject (
@@ -45,12 +70,11 @@ function copyRecursive (
   return pify(cpr)(source, target, CPR_OPTIONS)
 }
 
-function copyRoutes (
+function getRoutes (
   target /* : string */,
   stage /* : string */
-) /* : Promise<void> */ {
+) /* : Promise<Array<ServerlessRouteConfiguration>> */ {
   const projectPath = getProjectPath(target)
-  const routesPath = path.join(target, 'routes.json')
   return Promise.all([
     readRoutes(projectPath),
     scope.read(projectPath)
@@ -61,7 +85,6 @@ function copyRoutes (
       module: path.join('project', routeConfig.module),
       route: routeConfig.route
     })))
-    .then((routeConfigs) => writeJsonFile(routesPath, routeConfigs))
 }
 
 function copyWrapper (
@@ -75,6 +98,14 @@ function getProjectPath (
   target /* : string */
 ) /* : string */ {
   return path.join(target, 'project')
+}
+
+function getCors (
+  target /* : string */
+) /* : Promise<CorsConfiguration | false> */ {
+  const projectPath = getProjectPath(target)
+  return readCors(projectPath)
+    .then((cors) => cors ? validateCors(cors) : false)
 }
 
 function getFunctionName (
@@ -98,37 +129,23 @@ function registerFunctions (
     .then((content) => Promise.all([
       readRoutes(projectPath),
       yaml.safeLoad(content),
-      scope.read(projectPath),
-      readCors(projectPath)
+      scope.read(projectPath)
     ]))
     .then((results) => {
       const routeConfigs = results[0]
       const config = results[1]
       const cfg = results[2]
-      const cors = results[3]
 
       config.service = nonAlphaNumericToDashes(cfg.project)
       config.provider.region = cfg.region
       config.provider.stage = stage
-      if (cors && cors.origins) {
-        config.custom = {
-          cors: {
-            origins: cors.origins,
-            headers: cors.headers || values.DEFAULT_HEADERS
-          }
-        }
-      }
       config.functions = routeConfigs.reduce((functions, routeConfig, index) => {
         // The route must not start with a leading '/'
         const route = routeConfig.route.substr(1)
         const functionName = getFunctionName(index.toString(), stage, cfg.project)
         functions[index] = {
           events: values.METHODS.map((METHOD) => ({
-            http: {
-              cors: cors && cors.origins ? '${self:custom.cors}' : false, // eslint-disable-line no-template-curly-in-string
-              method: METHOD.toLowerCase(),
-              path: route
-            }
+            http: `${METHOD} ${route}`
           })),
           handler: `${HANDLER}.handler`,
           name: functionName,
@@ -150,11 +167,13 @@ function registerFunctions (
 
 module.exports = {
   applyTemplate,
+  copyConfiguration,
   copyProject,
   copyRecursive,
-  copyRoutes,
   copyWrapper,
+  getCors,
   getProjectPath,
   getFunctionName,
+  getRoutes,
   registerFunctions
 }

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,7 +1,17 @@
 'use strict'
 
+const DEFAULT_HEADERS = [
+  'Accept',
+  'Authorization',
+  'Content-Type',
+  'If-None-Match',
+  'X-Amz-Date',
+  'X-Amz-Security-Token',
+  'X-Api-Key'
+]
 const METHODS = [ 'DELETE', 'GET', 'OPTIONS', 'PATCH', 'POST', 'PUT' ]
 
 module.exports = {
+  DEFAULT_HEADERS,
   METHODS
 }

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,6 +1,8 @@
+/* @flow */
 'use strict'
 
-const DEFAULT_HEADERS = [
+const CREDENTIALS /* : boolean */ = false
+const HEADERS /* : Array<string> */ = [
   'Accept',
   'Authorization',
   'Content-Type',
@@ -9,9 +11,22 @@ const DEFAULT_HEADERS = [
   'X-Amz-Security-Token',
   'X-Api-Key'
 ]
-const METHODS = [ 'DELETE', 'GET', 'OPTIONS', 'PATCH', 'POST', 'PUT' ]
+const EXPOSED_HEADERS /* : Array<string> */ = [
+  'Server-Authorization',
+  'WWW-Authenticate'
+]
+const MAX_AGE /* : number */ = 86400 // 1 Day
+const ORIGINS /* : Array<string> */ = [ '*' ]
+
+const METHODS /* : Array<string> */ = [ 'DELETE', 'GET', 'OPTIONS', 'PATCH', 'POST', 'PUT' ]
 
 module.exports = {
-  DEFAULT_HEADERS,
+  DEFAULT_CORS: {
+    CREDENTIALS,
+    EXPOSED_HEADERS,
+    HEADERS,
+    MAX_AGE,
+    ORIGINS
+  },
   METHODS
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "execa": "0.5.0",
     "glob": "7.1.1",
     "good": "7.0.2",
-    "good-console": "6.1.2",
+    "good-console": "6.3.1",
     "hapi": "15.1.1",
     "js-yaml": "3.6.1",
     "load-json-file": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "pify": "2.3.0",
     "uniloc": "0.3.0",
     "update-notifier": "1.0.2",
+    "valid-url": "1.0.9",
     "write-json-file": "2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "hapi": "15.1.1",
     "js-yaml": "3.6.1",
     "load-json-file": "2.0.0",
+    "lodash.isboolean": "3.0.3",
+    "lodash.isnumber": "3.0.3",
     "meow": "3.7.0",
     "object-merge": "2.5.1",
     "pify": "2.3.0",

--- a/scripts/wrapper.js
+++ b/scripts/wrapper.js
@@ -37,37 +37,70 @@ function normaliseLambdaRequest (request) {
   }
 }
 
-function finish (cb, body, statusCode) {
+function finish (cb, body, statusCode, corsHeaders) {
   cb(null, {
     body: JSON.stringify(body),
-    headers: {
+    headers: Object.assign({
       'Content-Type': 'application/json'
-    },
+    }, corsHeaders),
     statusCode: statusCode
   })
 }
 
 function handler (event, context, cb) {
-  const routesPath = path.join(__dirname, 'routes.json')
-  return loadJsonFile(routesPath, 'utf8')
-    .then((routeConfigs) => {
-      const request = normaliseLambdaRequest(event)
-      const routeConfig = routeConfigs.find((routeConfig) => routeConfig.route === event.resource)
+  const request = normaliseLambdaRequest(event)
+  const configPath = path.join(__dirname, 'bm-server.json')
+  return loadJsonFile(configPath, 'utf8')
+    .then((config) => {
+      // Get handler module based on route
+      const routeConfig = config.routes.find((routeConfig) => routeConfig.route === event.resource)
       if (!routeConfig) {
         return finish(cb, 'Internal Server Error', 500)
       }
 
-      const handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
+      let handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
       if (!handler) {
         return finish(cb, 'Internal Server Error', 500)
       }
       if (typeof handler !== 'function') {
-        return finish(cb, 'Method Not Implemented', 405)
+        if (request.method === 'options') {
+          // If we couldnt find the options function we can just finish
+          // as we have created our own implementation of CORS
+          handler = () => {}
+        } else {
+          return finish(cb, 'Method Not Implemented', 405)
+        }
+      }
+
+      // Check for browser requests and apply CORS if required
+      let corsHeaders = {}
+      if (request.headers.origin) {
+        if (!config.cors) {
+          // No cors, we will return 405 result and let browser handler error
+          return finish(cb, 'Method Not Implemented', 405)
+        }
+        if (!config.cors.origins.some((origin) => origin === '*' || origin === request.headers.origin)) {
+          // Invalid origin, we will return 200 result and let browser handler error
+          return finish(cb, null, 200)
+        }
+        // Headers for all cross origin requests
+        corsHeaders['Access-Control-Allow-Origin'] = request.headers.origin
+        corsHeaders['Access-Control-Expose-Headers'] = config.cors.exposedHeaders.join(',')
+        // Headers for OPTIONS cross origin requests
+        if (request.method === 'options' && request.headers['access-control-request-method']) {
+          corsHeaders['Access-Control-Allow-Headers'] = config.cors.headers.join(',')
+          corsHeaders['Access-Control-Allow-Methods'] = request.headers['access-control-request-method']
+          corsHeaders['Access-Control-Max-Age'] = config.cors.maxAge
+        }
+        // Only set credentials header if truthy
+        if (config.cors.credentials) {
+          corsHeaders['Access-Control-Allow-Credentials'] = true
+        }
       }
 
       return handlers.executeHandler(handler, request)
-        // TODO: Allow for customer to set there own statusCode and headers (including CORS)
-        .then((result) => finish(cb, result, 200))
+        // TODO: Allow for customer to set there own statusCode and headers
+        .then((result) => finish(cb, result, 200, corsHeaders))
     })
     // TODO: extract error code from Boom-compatible errors
     .catch((error) => finish(cb, error && error.message ? error.message : (error || 'Internal Server Error'), 500))

--- a/test/cors/display.js
+++ b/test/cors/display.js
@@ -13,6 +13,10 @@ const CORS = {
   headers: [
     'Accept',
     'Content-Type'
+  ],
+  exposedHeaders: [
+    'Accept',
+    'Content-Type'
   ]
 }
 

--- a/test/cors/display.js
+++ b/test/cors/display.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const test = require('ava')
+const proxyquire = require('proxyquire')
+
+const TEST_SUBJECT = '../../lib/cors/display.js'
+
+const CWD = 'current working directory'
+const CORS = {
+  'origins': [
+    'http://test'
+  ],
+  headers: [
+    'Accept',
+    'Content-Type'
+  ]
+}
+
+test.beforeEach((t) => {
+  t.context.getTestSubject = (overrides) => {
+    overrides = overrides || {}
+    return proxyquire(TEST_SUBJECT, Object.assign({
+      './read.js': () => Promise.resolve(CORS),
+
+      './validate.js': () => Promise.resolve(CORS)
+    }, overrides))
+  }
+
+  t.context.logger = {
+    log: () => {}
+  }
+})
+
+test('Should call read() with correct input', (t) => {
+  t.plan(1)
+  const display = t.context.getTestSubject({
+    './read.js': (cwd) => {
+      t.is(cwd, CWD)
+      return Promise.resolve(CORS)
+    }
+  })
+
+  return display(t.context.logger, CWD)
+})
+
+test('Should call validate() with correct input', (t) => {
+  const display = t.context.getTestSubject({
+    './validate.js': (cors) => {
+      t.deepEqual(cors, CORS)
+      return Promise.resolve(cors)
+    }
+  })
+
+  return display(t.context.logger, CWD)
+})
+
+test('Should not log the cors and reject if no routes are found', (t) => {
+  t.plan(1)
+  const display = t.context.getTestSubject({
+    './validate.js': () => Promise.reject()
+  })
+
+  return display({log: () => t.fail('Should not log if there are no routes')}, CWD)
+    .catch(() => t.pass())
+})
+
+test('Should log the cors', (t) => {
+  t.plan(1)
+  const display = t.context.getTestSubject()
+
+  return display({log: () => t.pass()}, CWD)
+})

--- a/test/cors/read.js
+++ b/test/cors/read.js
@@ -35,7 +35,7 @@ test('Should call configuration.read() with correct input', (t) => {
   return read(CWD)
 })
 
-test('Should handle an unitinitalised config file', (t) => {
+test('Should handle an uninitialised config file', (t) => {
   t.plan(1)
   const read = t.context.getTestSubject({
     '../configuration.js': configurationMock((cwd) => Promise.resolve({

--- a/test/cors/read.js
+++ b/test/cors/read.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const test = require('ava')
+const proxyquire = require('proxyquire')
+
+const TEST_SUBJECT = '../../lib/cors/read.js'
+
+const configurationMock = require('../helpers/configuration.js')
+
+const CWD = 'current working directory'
+const CORS = 'cors configuration'
+
+test.beforeEach((t) => {
+  t.context.getTestSubject = (overrides) => {
+    overrides = overrides || {}
+    return proxyquire(TEST_SUBJECT, Object.assign({
+      '../configuration.js': configurationMock(() => Promise.resolve({
+        cors: CORS
+      }))
+    }, overrides))
+  }
+})
+
+test('Should call configuration.read() with correct input', (t) => {
+  t.plan(1)
+  const read = t.context.getTestSubject({
+    '../configuration.js': configurationMock((cwd) => {
+      t.is(cwd, CWD)
+      return Promise.resolve({
+        cors: CORS
+      })
+    })
+  })
+
+  return read(CWD)
+})
+
+test('Should handle an unitinitalised config file', (t) => {
+  t.plan(1)
+  const read = t.context.getTestSubject({
+    '../configuration.js': configurationMock((cwd) => Promise.resolve({
+      'test': 123
+    }))
+  })
+  return read()
+    .then((cors) => t.deepEqual(cors, {}))
+})
+
+test('Should return the currently set cors', (t) => {
+  const read = t.context.getTestSubject()
+
+  return read(CWD)
+    .then((cors) => t.deepEqual(cors, CORS))
+})
+
+test('Should reject if configuration.read() throws an error', (t) => {
+  const read = t.context.getTestSubject({
+    '../configuration.js': configurationMock((cwd) => Promise.reject(new Error('test')))
+  })
+
+  t.throws(read(CWD), 'test')
+})

--- a/test/cors/validate.js
+++ b/test/cors/validate.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const test = require('ava')
+
+const validate = require('../../lib/cors/validate.js')
+
+const HELP = ', see documentation for information on how to configure cors.'
+
+test('Should reject if cors is not truthy', (t) => {
+  t.throws(validate(), 'Must specify cors configuration' + HELP)
+})
+
+test('Should reject if cors does not have origins property', (t) => {
+  t.throws(validate({}), 'Must specify at least a single allowable origin in cors configuration' + HELP)
+})
+
+test('Should reject if origins is not an array', (t) => {
+  t.throws(validate({
+    origins: {}
+  }), 'Must specify at least a single allowable origin in cors configuration' + HELP)
+})
+
+test('Should reject if origins is an empty array', (t) => {
+  t.throws(validate({
+    origins: []
+  }), 'Must specify at least a single allowable origin in cors configuration' + HELP)
+})
+
+test('Should reject if origins contains "*"', (t) => {
+  t.throws(validate({
+    origins: ['*']
+  }), 'Cannot specify all origins as allowable in cors configuration i.e. "*"' + HELP)
+})
+
+test('Should reject if origins contains invalid urls', (t) => {
+  t.throws(validate({
+    origins: ['test', '123']
+  }), 'The following origins in cors configuration are not valid: test, 123')
+})
+
+test('Should reject if headers is defined but not as an array', (t) => {
+  t.throws(validate({
+    origins: ['http://test'],
+    headers: 'test'
+  }), 'Invalid headers in cors configuration' + HELP)
+})

--- a/test/cors/validate.js
+++ b/test/cors/validate.js
@@ -10,26 +10,24 @@ test('Should reject if cors is not truthy', (t) => {
   t.throws(validate(), 'Must specify cors configuration' + HELP)
 })
 
-test('Should reject if cors does not have origins property', (t) => {
-  t.throws(validate({}), 'Must specify at least a single allowable origin in cors configuration' + HELP)
-})
-
-test('Should reject if origins is not an array', (t) => {
-  t.throws(validate({
-    origins: {}
-  }), 'Must specify at least a single allowable origin in cors configuration' + HELP)
+test('Should reject if origins is undefined or is not an array', (t) => {
+  t.plan(5)
+  const configs = [
+    {},
+    { origins: 'test' },
+    { origins: 123 },
+    { origins: true },
+    { origins: {} }
+  ]
+  return configs.reduce((prev, config) => {
+    return prev.then(() => t.throws(validate(config), 'Must specify at least a single allowable origin in cors configuration' + HELP))
+  }, Promise.resolve())
 })
 
 test('Should reject if origins is an empty array', (t) => {
   t.throws(validate({
     origins: []
   }), 'Must specify at least a single allowable origin in cors configuration' + HELP)
-})
-
-test('Should reject if origins contains "*"', (t) => {
-  t.throws(validate({
-    origins: ['*']
-  }), 'Cannot specify all origins as allowable in cors configuration i.e. "*"' + HELP)
 })
 
 test('Should reject if origins contains invalid urls', (t) => {
@@ -39,8 +37,65 @@ test('Should reject if origins contains invalid urls', (t) => {
 })
 
 test('Should reject if headers is defined but not as an array', (t) => {
-  t.throws(validate({
+  t.plan(4)
+  const configs = [
+    { origins: ['http://test'], headers: 'test' },
+    { origins: ['http://test'], headers: 123 },
+    { origins: ['http://test'], headers: true },
+    { origins: ['http://test'], headers: {} }
+  ]
+  return configs.reduce((prev, config) => {
+    return prev.then(() => t.throws(validate(config), 'Headers must be an array of strings in cors configuration' + HELP))
+  }, Promise.resolve())
+})
+
+test('Should reject if exposed headers is defined but not as an array', (t) => {
+  t.plan(4)
+  const configs = [
+    { origins: ['http://test'], exposedHeaders: 'test' },
+    { origins: ['http://test'], exposedHeaders: 123 },
+    { origins: ['http://test'], exposedHeaders: true },
+    { origins: ['http://test'], exposedHeaders: {} }
+  ]
+  return configs.reduce((prev, config) => {
+    return prev.then(() => t.throws(validate(config), 'Exposed headers must be an array of strings in cors configuration' + HELP))
+  }, Promise.resolve())
+})
+
+test('Should reject if max age is not a number', (t) => {
+  t.plan(4)
+  const configs = [
+    { origins: ['http://test'], maxAge: 'test' },
+    { origins: ['http://test'], maxAge: true },
+    { origins: ['http://test'], maxAge: [] },
+    { origins: ['http://test'], maxAge: {} }
+  ]
+  return configs.reduce((prev, config) => {
+    return prev.then(() => t.throws(validate(config), 'Max age must be a number in cors configuration' + HELP))
+  }, Promise.resolve())
+})
+
+test('Should reject if credentials is not a boolean', (t) => {
+  t.plan(4)
+  const configs = [
+    { origins: ['http://test'], maxAge: 1, credentials: 'test' },
+    { origins: ['http://test'], maxAge: 1, credentials: 123 },
+    { origins: ['http://test'], maxAge: 1, credentials: [] },
+    { origins: ['http://test'], maxAge: 1, credentials: {} }
+  ]
+  return configs.reduce((prev, config) => {
+    return prev.then(() => t.throws(validate(config), 'Credentials must be a boolean in cors configuration' + HELP))
+  }, Promise.resolve())
+})
+
+test('Should resolve input if all cors is valid', (t) => {
+  const cors = {
     origins: ['http://test'],
-    headers: 'test'
-  }), 'Invalid headers in cors configuration' + HELP)
+    headers: ['test'],
+    exposedHeaders: ['test'],
+    maxAge: 1,
+    credentials: true
+  }
+  return validate(cors)
+    .then((validated) => t.deepEqual(validated, cors))
 })


### PR DESCRIPTION
### Added
- SC-24: Display of CORS for `bm server info` cmd
- SC-24: CORS to `bm server serverless` when generating a serverless project
- SC-24: CORS to `bm server serve` when locally hosting routes
  - Will still run if CORS is not setup, and will use [hapi](http://hapijs.com/api#route-options) defaults
### Code Review Notes
- Probably worth reviewing these one commit at a time
- Known incomplete work to be tackled in future:
  - [ ] Monitor this [serverless issue](https://github.com/serverless/serverless/issues/2476) and ensure the `bm server serverless` cmd is compatible with the fix
