### PR TITLE
SC-25 # Updated serverless wrapper to use lambda proxy syntax

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -51,7 +51,7 @@ try {
   main = require(path.join(__dirname, '..', 'commands', `${command}.js`))
 } catch (err) {
   console.error(chalk.red(`
-Unknown command: ${command}`, err))
+Unknown command: ${command}`))
   cli.showHelp(1)
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,7 @@ Usage: blinkm server <command> <project_path>
 
 Commands:
   serve                   => start a local development server using local API files
+    --port <port>         => sets the port to use for server
   info                    => displays project information
   scope                   => displays the current scope
     --project <project>   => sets the project id
@@ -34,6 +35,7 @@ const cli = meow({
   },
   string: [
     'out',
+    'port',
     'stage'
   ]
 })
@@ -49,7 +51,7 @@ try {
   main = require(path.join(__dirname, '..', 'commands', `${command}.js`))
 } catch (err) {
   console.error(chalk.red(`
-Unknown command: ${command}`))
+Unknown command: ${command}`, err))
   cli.showHelp(1)
 }
 

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -2,25 +2,30 @@
 
 const path = require('path')
 
+const chalk = require('chalk')
+
 const serve = require('../lib/serve.js')
 
 module.exports = function (input, flags, logger, options) {
   const cwd = path.resolve(options.cwd)
-  const example = path.join(cwd, 'helloworld', 'index.js')
+  const example = path.join('helloworld', 'index.js')
   return serve.startServer({
     cwd,
-    port: 3000
+    port: flags.port || 3000
   })
-    .then((server) => logger.log(`
-HTTP service for local development is running at port ${server.info.port}
+  .then((server) => logger.log(`
+HTTP service for local development is available from:
+  ${server.info.uri}
 
 Your current directory "." is:
   ${cwd}
 
 HTTP API files should be in sub-folders within the directory above E.g:
-  ${example}
+  ${example} -> ${server.info.uri}/helloworld
 
-Create new HTTP APIs, rename, update, or delete them at any time
+Create new HTTP APIs, rename, update, or delete them at any time.
 Your changes automatically take effect on the next request
+
+${chalk.yellow('Hit CTRL-C to stop the service')}
 `))
 }

--- a/dist/wrapper.js
+++ b/dist/wrapper.js
@@ -1913,54 +1913,61 @@ const wrapper = require('../lib/wrapper.js')
 // return only the pertinent data from a API Gateway + Lambda event
 function normaliseLambdaRequest (request) {
   const headers = wrapper.keysToLowerCase(request.headers)
+  let body = request.body
+  try {
+    body = JSON.parse(body)
+  } catch (e) {
+    // Do nothing...
+  }
   return {
-    body: request.body,
+    body,
     headers,
-    method: wrapper.normaliseMethod(request.method),
+    method: wrapper.normaliseMethod(request.httpMethod),
     url: {
       host: headers.host,
       hostname: headers.host,
-      params: request.path,
+      params: request.pathParameters || {},
+      pathname: request.path,
       protocol: wrapper.protocolFromHeaders(headers),
-      query: request.query
+      query: request.queryStringParameters || {}
     }
   }
 }
 
+function finish (cb, body, statusCode) {
+  cb(null, {
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    statusCode: statusCode
+  })
+}
+
 function handler (event, context, cb) {
-  // TODO: extract error code from Boom-compatible errors
-  // TODO: error handling needs to match Serverless' APIG error templates
   const routesPath = path.join(__dirname, 'routes.json')
   return loadJsonFile(routesPath, 'utf8')
     .then((routeConfigs) => {
       const request = normaliseLambdaRequest(event)
-      const routeConfig = routeConfigs.find((routeConfig) => routeConfig.functionName === context.functionName)
+      const routeConfig = routeConfigs.find((routeConfig) => routeConfig.route === event.resource)
       if (!routeConfig) {
-        return Promise.reject(new Error('[500] Internal Server Error'))
+        return finish(cb, 'Internal Server Error', 500)
       }
-      request.url.pathname = routeConfig.route
-      // Replace params in route to get pathname
-      Object.keys(request.url.params).forEach((key) => {
-        const val = request.url.params[key]
-        request.url.pathname = request.url.pathname.replace(`{${key}}`, val)
-      })
-      const handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
 
+      const handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
       if (!handler) {
-        return Promise.reject(new Error('[500] Internal Server Error'))
+        return finish(cb, 'Internal Server Error', 500)
       }
       if (typeof handler !== 'function') {
-        return Promise.reject(new Error('[501] Not Implemented'))
+        return finish(cb, 'Method Not Implemented', 405)
       }
 
-      // TODO: transparently implement HEAD
-
       return handlers.executeHandler(handler, request)
-        .then((result) => {
-          cb(null, result || 200)
-        })
+        // TODO: Allow for customer to set there own statusCode and headers (including CORS)
+        .then((result) => finish(cb, result, 200))
     })
-    .catch((err) => cb(err))
+    // TODO: extract error code from Boom-compatible errors
+    .catch((error) => finish(cb, error && error.message ? error.message : (error || 'Internal Server Error'), 500))
 }
 
 module.exports = {


### PR DESCRIPTION
### Added
- SC-25: `--port` flag to `bm server serve` cmd
### Changed
- SC-25: Serverless wrapper handler to accommodate for `lambda-proxy` integration
### Code Review Notes
- Known incomplete work to be tackled in future:
  - [ ] Allow for customer to set there own status code and headers (including CORS)
  - [ ] Updated error handling to output more information when errors thrown.
