### PR TITLE
SC-19 # Return appropriate HTTP Status Code based on error thrown

### DIFF
--- a/dist/wrapper.js
+++ b/dist/wrapper.js
@@ -13,18 +13,17 @@ function executeHandler (
 function getHandler (
   module /* : string */,
   method /* : string */
-) /* : Function | void */ {
-  let handler
+) /* : Promise<Function | void> */ {
   try {
     // $FlowIssue in this case, we explicitly `require()` dynamically
-    handler = require(module)
+    let handler = require(module)
     if (handler && method && typeof handler[method] === 'function') {
       handler = handler[method]
     }
+    return Promise.resolve(handler)
   } catch (err) {
-    // do nothing
+    return Promise.reject(err)
   }
-  return handler
 }
 
 module.exports = {
@@ -1934,31 +1933,34 @@ function normaliseLambdaRequest (request) {
   }
 }
 
-function finish (cb, body, statusCode, internalHeaders) {
-  cb(null, {
-    body: JSON.stringify(body),
-    headers: Object.assign({
-      'Content-Type': 'application/json'
-    }, internalHeaders),
-    statusCode: statusCode
-  })
-}
-
 function handler (event, context, cb) {
   const request = normaliseLambdaRequest(event)
   const configPath = path.join(__dirname, 'bm-server.json')
-  const internalHeaders = {}
+  const internalHeaders = {
+    'Content-Type': 'application/json'
+  }
+  const finish = (statusCode, body, customHeaders) => {
+    cb(null, {
+      body: JSON.stringify(body, null, 2),
+      headers: Object.assign(internalHeaders, customHeaders),
+      statusCode: statusCode
+    })
+  }
   return loadJsonFile(configPath, 'utf8')
     .then((config) => {
       // Check for browser requests and apply CORS if required
       if (request.headers.origin) {
         if (!config.cors) {
           // No cors, we will return 405 result and let browser handler error
-          return finish(cb, 'Method Not Implemented', 405)
+          return finish(405, {
+            error: 'Method Not Allowed',
+            message: 'OPTIONS method has not been implemented',
+            statusCode: 405
+          })
         }
         if (!config.cors.origins.some((origin) => origin === '*' || origin === request.headers.origin)) {
           // Invalid origin, we will return 200 result and let browser handler error
-          return finish(cb, undefined, 200)
+          return finish(200)
         }
         // Headers for all cross origin requests
         internalHeaders['Access-Control-Allow-Origin'] = request.headers.origin
@@ -1977,26 +1979,29 @@ function handler (event, context, cb) {
       if (request.method === 'options') {
         // For OPTIONS requests, we can just finish
         // as we have created our own implementation of CORS
-        return finish(cb, undefined, 200, internalHeaders)
+        return finish(200)
       }
 
       // Get handler module based on route
       const routeConfig = config.routes.find((routeConfig) => routeConfig.route === event.resource)
       if (!routeConfig) {
-        return finish(cb, 'Internal Server Error', 500)
+        return Promise.reject(new Error(`Could not find route configuration for route: ${event.resource}`))
       }
 
-      let handler = handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
-      if (!handler) {
-        return finish(cb, 'Internal Server Error', 500)
-      }
-      if (typeof handler !== 'function') {
-        return finish(cb, 'Method Not Implemented', 405)
-      }
+      return handlers.getHandler(path.join(__dirname, routeConfig.module), request.method)
+        .then((handler) => {
+          if (typeof handler !== 'function') {
+            return finish(405, {
+              error: 'Method Not Allowed',
+              message: `${request.method.toUpperCase()} method has not been implemented`,
+              statusCode: 405
+            })
+          }
 
-      return handlers.executeHandler(handler, request)
-        // TODO: Allow for customer to set there own statusCode and headers
-        .then((result) => finish(cb, result, 200, internalHeaders))
+          return handlers.executeHandler(handler, request)
+            // TODO: Allow for customer to set there own statusCode and headers
+            .then((result) => finish(200, result))
+        })
     })
     .catch((error) => {
       if (error && error.isBoom && error.output && error.output.payload && error.output.statusCode) {
@@ -2005,13 +2010,13 @@ function handler (event, context, cb) {
         // Options:
         // 1. Include in response, prob not safe. Could include sensitive information
         // 2. Log to something in AWS, Not sure if this is possible ???
-        return finish(cb, error.output.payload, error.output.statusCode, Object.assign(internalHeaders, error.output.headers))
+        return finish(error.output.statusCode, error.output.payload, error.output.headers)
       }
-      finish(cb, {
+      finish(500, {
         error: 'Internal Server Error',
         message: 'An internal server error occurred',
         statusCode: 500
-      }, 500, internalHeaders)
+      })
     })
 }
 

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -19,25 +19,20 @@ const handlers = require('./handlers.js')
 const readRoutes = require('./routes/read.js')
 
 function getHandlerConfig (
-  cwd /* : string */,
-  route /* : string */,
+  routeConfig /* : RouteConfiguration */,
   method /* : string */
 ) /* : Promise<HandlerConfiguration> */ {
-  return getRouteConfig(cwd, route)
-    .then((routeConfig) => {
-      routeConfig = routeConfig || {}
-      const handler = handlers.getHandler(routeConfig.module, method)
-      return {
-        handler,
-        params: routeConfig.params
-      }
-    })
+  return handlers.getHandler(routeConfig.module, method)
+    .then((handler) => ({
+      handler,
+      params: routeConfig.params || {}
+    }))
 }
 
 function getRouteConfig (
   cwd /* : string */,
   route /* : string */
-) /* : Promise<RouteConfiguration | void> */ {
+) /* : Promise<RouteConfiguration> */ {
   return readRoutes(cwd)
     .then((routes) => {
       routes = routes || []
@@ -46,29 +41,27 @@ function getRouteConfig (
         return memo
       }, {})
       const unilocRouter = uniloc(unilocRoutes)
-      const unilocRoute = unilocRouter.lookup(route, 'GET')
-      if (unilocRoute) {
-        const routeConfig = routes.find((routeConfig) => routeConfig.route === unilocRoute.name)
-        if (routeConfig) {
-          routeConfig.module = path.resolve(cwd, routeConfig.module)
-          routeConfig.params = unilocRoute.options
-          return routeConfig
-        }
+      const unilocRoute = unilocRouter.lookup(route, 'GET') || {}
+
+      const routeConfig = routes.find((routeConfig) => routeConfig.route === unilocRoute.name)
+      if (!routeConfig) {
+        return Promise.reject(new Error(`Route has not been implemented: /${route}`))
       }
+
+      routeConfig.module = path.resolve(cwd, routeConfig.module)
+      routeConfig.params = unilocRoute.options
+      wipeRouteFromRequireCache(routeConfig)
+      return routeConfig
     })
 }
 
 function wipeRouteFromRequireCache (
-  cwd /* : string */,
-  route /* : string */
-) /* : Promise<void> */ {
+  routeConfig /* : RouteConfiguration */
+) /* : void */ {
   // property names in require.cache are absolute paths
-  return getRouteConfig(cwd, route)
-    .then(routeConfig => {
-      if (routeConfig) {
-        delete require.cache[routeConfig.module]
-      }
-    })
+  if (routeConfig && require.cache[routeConfig.module]) {
+    delete require.cache[routeConfig.module]
+  }
 }
 
 module.exports = {

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -12,18 +12,17 @@ function executeHandler (
 function getHandler (
   module /* : string */,
   method /* : string */
-) /* : Function | void */ {
-  let handler
+) /* : Promise<Function | void> */ {
   try {
     // $FlowIssue in this case, we explicitly `require()` dynamically
-    handler = require(module)
+    let handler = require(module)
     if (handler && method && typeof handler[method] === 'function') {
       handler = handler[method]
     }
+    return Promise.resolve(handler)
   } catch (err) {
-    // do nothing
+    return Promise.reject(err)
   }
-  return handler
 }
 
 module.exports = {

--- a/lib/project.js
+++ b/lib/project.js
@@ -21,8 +21,7 @@ function listRoutes (
   return listAPIs(cwd)
     .then((apis) => apis.map((api) => ({
       route: `/${api}`,
-      module: `./${api}/index.js`,
-      params: {}
+      module: `./${api}/index.js`
     })))
 }
 

--- a/lib/routes/read.js
+++ b/lib/routes/read.js
@@ -8,7 +8,7 @@ const project = require('../project.js')
 export type RouteConfiguration = {
   route: string,
   module: string,
-  params: {[id:string]: string}
+  params?: {[id:string]: string}
 }
 */
 

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -60,15 +60,12 @@ function startServer (options) {
         return
       }
 
-      apis.wipeRouteFromRequireCache(cwd, route)
-        .then(() => apis.getHandlerConfig(cwd, route, request.method))
+      apis.getRouteConfig(cwd, route)
+        .catch((err) => Promise.reject(Boom.wrap(err, 404)))
+        .then((routeConfig) => apis.getHandlerConfig(routeConfig, request.method))
         .then((handlerConfig) => {
-          if (!handlerConfig || !handlerConfig.handler) {
-            reply(Boom.notFound(`Route has not been implemented: ${route}`)) // 404
-            return
-          }
           if (typeof handlerConfig.handler !== 'function') {
-            reply(Boom.methodNotAllowed(`${request.method.toUpperCase()} method has not been implemented for route: ${route}`, {test: 123}, ['GET', 'POST'])) // 405
+            reply(Boom.methodNotAllowed(`${request.method.toUpperCase()} method has not been implemented`)) // 405
             return
           }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -163,8 +163,6 @@ function registerFunctions (
     )
 }
 
-// TODO: configure CORS
-
 module.exports = {
   applyTemplate,
   copyConfiguration,

--- a/test/handlers.js
+++ b/test/handlers.js
@@ -20,18 +20,28 @@ test('executeHandler()', (t) => {
     .then(() => t.truthy(isHandlerCalled))
 })
 
-test('getHandler()', (t) => {
+test('getHandler() valid modules', (t) => {
   const tests = [
-    { args: [ path.join(EXAMPLE_DIR, 'missing'), 'get' ], expected: 'undefined' },
     { args: [ path.join(EXAMPLE_DIR, 'helloworld'), 'get' ], expected: 'function' },
     { args: [ path.join(EXAMPLE_DIR, 'methods'), 'get' ], expected: 'function' },
     { args: [ path.join(EXAMPLE_DIR, 'methods'), 'patch' ], expected: 'object' },
-    { args: [ path.join(CONFIGURATION_DIR, 'api/missing'), 'get' ], expected: 'undefined' },
     { args: [ path.join(CONFIGURATION_DIR, 'api/request'), 'get' ], expected: 'function' },
     { args: [ path.join(CONFIGURATION_DIR, 'api/books'), 'get' ], expected: 'function' },
     { args: [ path.join(CONFIGURATION_DIR, 'api/books'), 'patch' ], expected: 'object' }
   ]
-  tests.forEach(({ args, expected }) => {
-    t.is(typeof lib.getHandler(...args), expected)
-  })
+  return tests.reduce((prev, config) => {
+    return prev.then(() => lib.getHandler(...config.args))
+      .then(result => t.is(typeof result, config.expected))
+  }, Promise.resolve())
+})
+
+test('getHandler() invalid modules', (t) => {
+  const tests = [
+    { args: [ path.join(EXAMPLE_DIR, 'missing'), 'get' ], expected: `Cannot find module '${path.join(EXAMPLE_DIR, 'missing')}'` },
+    { args: [ path.join(CONFIGURATION_DIR, 'api/missing'), 'get' ], expected: `Cannot find module '${path.join(CONFIGURATION_DIR, 'api/missing')}'` }
+  ]
+
+  return tests.reduce((prev, config) => {
+    return prev.then(() => t.throws(lib.getHandler(...config.args), config.expected))
+  }, Promise.resolve())
 })

--- a/test/project.js
+++ b/test/project.js
@@ -25,28 +25,23 @@ test('listRoutes()', (t) => {
   const expected = [
     {
       'route': '/boom',
-      'module': './boom/index.js',
-      'params': {}
+      'module': './boom/index.js'
     },
     {
       'route': '/helloworld',
-      'module': './helloworld/index.js',
-      'params': {}
+      'module': './helloworld/index.js'
     },
     {
       'route': '/methods',
-      'module': './methods/index.js',
-      'params': {}
+      'module': './methods/index.js'
     },
     {
       'route': '/promise',
-      'module': './promise/index.js',
-      'params': {}
+      'module': './promise/index.js'
     },
     {
       'route': '/request',
-      'module': './request/index.js',
-      'params': {}
+      'module': './request/index.js'
     }
   ]
   return lib.listRoutes(EXAMPLE_DIR)


### PR DESCRIPTION
### Added

- SC-19: Allow handlers to throw or reject [Boom](https://www.npmjs.com/package/boom) errors  with consistent results between local development and deployment. The following are intentionally inconsistent:

   - Error messages for 500 responses are shown in development but not when deployed. E.g. If a `require()` statement throws and error, the error message will be sent to the referer in development.

### Code Review Notes

- Probably worth reviewing these one commit at a time. I accidentally committed the first two commits directly to master:
   - https://github.com/blinkmobile/server-cli/commit/06521997bc389d9a08252ece36272ce26c017034
   - https://github.com/blinkmobile/server-cli/commit/502ff03a548510716786d1b6af466a8c8296f07e

- Known incomplete work to be tackled in future:

    - [ ] Ensure docs specify that 500 error messages will only be returned locally.
    - [ ] Allow for handlers to return there own statusCode and headers for success responses.
    - [ ] Make sure the docs indicate what we do with the [data] argument of all [Boom](https://www.npmjs.com/package/boom) functions. It is available through `error.data` and it currently being ignored.