### PR TITLE
Revert "Update inquirer to version 1.3.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "good": "7.0.2",
     "good-console": "6.3.1",
     "hapi": "15.1.1",
-    "inquirer": "1.3.0",
+    "inquirer": "1.2.3",
     "js-yaml": "3.7.0",
     "load-json-file": "2.0.0",
     "log-symbols": "^1.0.2",


### PR DESCRIPTION
-   Reverts blinkmobile/server-cli#47

-   [inquirer](https://www.npmjs.com/package/inquirer) never published [1.3.0](https://github.com/SBoudrias/Inquirer.js/releases/tag/v1.3.0) to npm:

    > Unpublished due to backward compatibility issue
