### PR TITLE
SC-38 # Using project to assume AWS role and get scoped service settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,32 @@ bm server --help
 ```
 Usage: blinkm server <command> <project_path>
 
-Commands:
+Where command is one of:
+
+  info, serve, scope, deploy
+
+And project_path is path to project directory, defaults to current working directory
+
+Local development:
+
+  info                    => displays project information
   serve                   => start a local development server using local API files
     --port <port>         => sets the port to use for server
-  info                    => displays project information
+
+Initial settings:
+
   scope                   => displays the current scope
     --project <project>   => sets the project id
     --region <region>     => optionally sets the region
+
+Deploying server side code:
+
+  The deploy command requires a login to BlinkMobile before use.
+  For help on the login and logout commands please see:
+  https://github.com/blinkmobile/identity-cli#usage
+
   deploy                  => deploy the project
     --force               => deploy without confirmation
-    --stage <stage>       => optionally sets the stage to deploy to, defaults to 'test'
 ```
 
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -28,16 +28,23 @@ Where command is one of:
 And project_path is path to project directory, defaults to current working directory
 
 Local development:
+
   info                    => displays project information
   serve                   => start a local development server using local API files
     --port <port>         => sets the port to use for server
 
 Initial settings:
+
   scope                   => displays the current scope
     --project <project>   => sets the project id
     --region <region>     => optionally sets the region
 
 Deploying server side code:
+
+  The deploy command requires a login to BlinkMobile before use.
+  For help on the login and logout commands please see:
+  https://github.com/blinkmobile/identity-cli#usage
+
   deploy                  => deploy the project
     --force               => deploy without confirmation
 `

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -12,7 +12,7 @@ module.exports = function (input, flags, logger, options) {
     .then(() => deploy.confirm(logger, force))
     .then((confirmation) => {
       if (confirmation) {
-        return deploy.authenticate(blinkMobileIdentity)
+        return deploy.authenticate(cwd, blinkMobileIdentity)
           .then((results) => {
             const awsCredentials = results[0]
             const serviceSettings = results[1]

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -22,7 +22,6 @@ By setting cors to `false`, Cross-Origin resource sharing will not be allowed. *
 
 ```json
 {
-  "project": "project-id",
   "server": {
     "cors": false
   }
@@ -33,7 +32,6 @@ By setting cors to `true`, defaults below will be used.
 
 ```json
 {
-  "project": "project-id",
   "server": {
     "cors": true
   }
@@ -44,7 +42,6 @@ By setting cors to `true`, defaults below will be used.
 
 ```json
 {
-  "project": "project-id",
   "server": {
     "cors": {
       "origins": [

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -58,7 +58,6 @@ The following route definitions:
 
 ```json
 {
-  "project": "project-id",
   "server": {
     "routes": [
       {

--- a/examples/configuration/.blinkmrc.json
+++ b/examples/configuration/.blinkmrc.json
@@ -1,7 +1,7 @@
 {
-  "project": "example-configuration",
-  "region": "ap-southeast-2",
   "server": {
+    "project": "example-configuration",
+    "region": "ap-southeast-2",
     "cors": true,
     "routes": [
       {

--- a/examples/directory/.blinkmrc.json
+++ b/examples/directory/.blinkmrc.json
@@ -1,7 +1,7 @@
 {
-  "project": "example-directory",
-  "region": "ap-southeast-2",
   "server": {
+    "project": "example-directory",
+    "region": "ap-southeast-2",
     "cors": true
   }
 }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -34,19 +34,23 @@ const inquirer = require('inquirer')
 const logSymbols = require('log-symbols')
 const logUpdates = require('./utils/log-updates.js')
 const request = require('request')
+const scope = require('./scope.js')
 const temp = require('temp').track()
 
 const EXT = 'zip'
 
 function authenticate (
+  cwd /* : string */,
   blinkMobileIdentity /* : BlinkMobileIdentity */
 ) /* : Promise<BMServerAuthentication> */ {
   const stopUpdates = logUpdates(() => 'Authenticating...')
-  return Promise.all([
-    blinkMobileIdentity.assumeAWSRole(),
-    blinkMobileIdentity.getServiceSettings(),
-    blinkMobileIdentity.getAccessToken()
-  ])
+  return scope.read(cwd)
+    .then((config) => ({ bmProject: config.project }))
+    .then((parameters) => Promise.all([
+      blinkMobileIdentity.assumeAWSRole(parameters),
+      blinkMobileIdentity.getServiceSettings(parameters),
+      blinkMobileIdentity.getAccessToken()
+    ]))
     .then((results) => {
       stopUpdates((logUpdater) => logUpdater(logSymbols.success, 'Authentication complete!'))
       return results

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -2,7 +2,10 @@
 'use strict'
 
 /* ::
-import type {BlinkMRC} from '../types.js'
+import type {
+  BlinkMRC,
+  BlinkMRCServer
+} from '../types.js'
 */
 
 const chalk = require('chalk')
@@ -13,9 +16,9 @@ const projectMeta = require('./utils/project-meta.js')
 
 function read (
   cwd /* : string */
-) /* : Promise<BlinkMRC> */ {
+) /* : Promise<BlinkMRCServer> */ {
   return projectMeta.read(cwd)
-    .then((cfg) => cfg || {})
+    .then((cfg) => cfg && cfg.server ? cfg.server : {})
 }
 
 function display (
@@ -48,18 +51,20 @@ function display (
 
 function write (
   cwd /* : string */,
-  meta /* : BlinkMRC */
-) /* : Promise<BlinkMRC> */ {
+  meta /* : BlinkMRCServer */
+) /* : Promise<BlinkMRCServer> */ {
   meta = meta || {}
   if (!meta.project) {
     return Promise.reject(new Error('meta.project was not defined.'))
   }
 
   return projectMeta.write(cwd, (config) => objectMerge(config, {
-    project: meta.project,
-    region: meta.region
+    server: {
+      project: meta.project,
+      region: meta.region
+    }
   }))
-    .then((cfg) => cfg)
+    .then((cfg) => cfg.server || {})
 }
 
 module.exports = {

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -69,7 +69,7 @@ test('authenticate() should call blinkMobileIdentity functions and stop updates'
       }
     }
   })
-  return deploy.authenticate({
+  return deploy.authenticate(ZIP_PATH, {
     // Ensure blinkMobileIdentity functions are called
     assumeAWSRole: () => {
       t.pass()
@@ -101,7 +101,7 @@ test('authenticate() should call log correct updates if blinkMobileIdentity func
       }
     }
   })
-  return deploy.authenticate({
+  return deploy.authenticate(ZIP_PATH, {
     assumeAWSRole: () => Promise.reject(new Error('test error')),
     getServiceSettings: () => Promise.resolve(),
     getAccessToken: () => Promise.resolve()

--- a/test/scope.js
+++ b/test/scope.js
@@ -6,8 +6,10 @@ const proxyquire = require('proxyquire')
 const TEST_SUBJECT = '../lib/scope.js'
 const CWD = 'current working directory'
 const CFG = {
-  project: 'name of project',
-  region: 'name of region'
+  server: {
+    project: 'name of project',
+    region: 'name of region'
+  }
 }
 
 test.beforeEach((t) => {
@@ -55,7 +57,7 @@ test('read() should return the currently set scope', (t) => {
   const scope = t.context.getTestSubject()
 
   return scope.read(CWD)
-    .then((server) => t.deepEqual(server, CFG))
+    .then((server) => t.deepEqual(server, CFG.server))
 })
 
 test('read() should reject if projectMeta.read() throws an error', (t) => {
@@ -126,7 +128,9 @@ test('write() should merge new scope with the current config', (t) => {
     bmp: {
       scope: 'blah'
     },
-    project: 'old',
+    server: {
+      project: 'old'
+    },
     extra: 'existing'
   }
   const newConfig = {
@@ -144,11 +148,7 @@ test('write() should merge new scope with the current config', (t) => {
 
   return scope.write(CWD, newConfig)
     .then((config) => t.deepEqual(config, {
-      bmp: {
-        scope: 'blah'
-      },
       project: 'new project',
-      region: 'new region',
-      extra: 'existing'
+      region: 'new region'
     }))
 })

--- a/types.js
+++ b/types.js
@@ -7,12 +7,14 @@ import type BmResponse from './lib/bm-response.js'
 
 /* ::
 export type BlinkMRC = {
+  server?: BlinkMRCServer
+}
+
+export type BlinkMRCServer = {
   project?: string,
   region?: string,
-  server?: {
-    cors?: CorsConfiguration | boolean,
-    routes?: Array<RouteConfiguration>
-  }
+  cors?: CorsConfiguration | boolean,
+  routes?: Array<RouteConfiguration>
 }
 
 export type BmRequest = {


### PR DESCRIPTION
### Added

-   Project identifier to parameters passed for
     -    Assuming AWS role
     -    Requesting service settings

-   Message to CLI `--help` to indicate the `deploy` command requires a login using `bm identity login`

### Changed

-    Moved scope `project` and `region` properties back into the `server` property