### PR TITLE
SC-44 # Set scope without needing --project flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@
 -   Example project names to be more realistic
 
 -   **BREAKING CHANGE**: `--stage` flag to `--env`, functionality has not changed.
+
+-   **BREAKING CHANGE**: `<project_path>` input option to a `--cwd` flag for all CLI commands
+
+-   **BREAKING CHANGE**: `bm server scope --project <project>` now sets project using `bm server scope <project>`

--- a/README.md
+++ b/README.md
@@ -20,25 +20,26 @@ bm server --help
 ```
 
 ```
-Usage: blinkm server <command> <project_path>
+Usage: blinkm server <command>
 
 Where command is one of:
 
   info, serve, scope, deploy
 
-And project_path is path to project directory, defaults to current working directory
-
 Local development:
 
   info                    => displays project information
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
   serve                   => start a local development server using local API files
-    --port <port>         => sets the port to use for server
+    --port <port>         => sets the port to use for server, defaults to 3000
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
 
 Initial settings:
 
   scope                   => displays the current scope
-    --project <project>   => sets the project id
+    <project>             => sets the project id
     --region <region>     => optionally sets the region
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
 
 Deploying server side code:
 
@@ -49,6 +50,7 @@ Deploying server side code:
   deploy                  => deploy the project
     --force               => deploy without confirmation
     --env <environment>   => optionally sets the environment to deploy to, defaults to 'dev'
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
 ```
 
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,25 +19,26 @@ const blinkMobileIdentity = new BlinkMobileIdentity(pkg.name)
 updateNotifier({ pkg }).notify()
 
 const help = `
-Usage: blinkm server <command> <project_path>
+Usage: blinkm server <command>
 
 Where command is one of:
 
   info, serve, scope, deploy
 
-And project_path is path to project directory, defaults to current working directory
-
 Local development:
 
   info                    => displays project information
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
   serve                   => start a local development server using local API files
-    --port <port>         => sets the port to use for server
+    --port <port>         => sets the port to use for server, defaults to 3000
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
 
 Initial settings:
 
   scope                   => displays the current scope
-    --project <project>   => sets the project id
+    <project>             => sets the project id
     --region <region>     => optionally sets the region
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
 
 Deploying server side code:
 
@@ -48,6 +49,7 @@ Deploying server side code:
   deploy                  => deploy the project
     --force               => deploy without confirmation
     --env <environment>   => optionally sets the environment to deploy to, defaults to 'dev'
+    --cwd <path>          => optionally set the path to project, defaults to current working directory
 `
 
 const cli = meow({
@@ -58,10 +60,12 @@ const cli = meow({
     'force'
   ],
   default: {
+    'cwd': process.cwd(),
     'force': false,
     'env': 'dev'
   },
   string: [
+    'cwd',
     'out',
     'port',
     'env'
@@ -91,7 +95,7 @@ Command not implemented: ${command}`))
 
 const input = cli.input.slice(1)
 const options = {
-  cwd: input[0] || process.cwd(),
+  cwd: cli.flags.cwd,
   blinkMobileIdentity
 }
 

--- a/commands/scope.js
+++ b/commands/scope.js
@@ -6,7 +6,7 @@ const REGION = 'ap-southeast-2'
 
 module.exports = function (input, flags, logger, options) {
   const cwd = options.cwd
-  const project = flags.project
+  const project = input[0]
   const region = flags.region || REGION
   let promise = Promise.resolve()
   if (project) {

--- a/lib/utils/project-meta.js
+++ b/lib/utils/project-meta.js
@@ -22,6 +22,7 @@ function read (
   cwd /* : string */
 ) /* : Promise<BlinkMRC> */ {
   return projectConfig(cwd).load()
+    .catch(() => ({}))
 }
 
 function write (

--- a/test/utils/project-meta.js
+++ b/test/utils/project-meta.js
@@ -32,6 +32,19 @@ test('projectConfig() call configLoader with correct input', (t) => {
   projectMeta.projectConfig(CWD)
 })
 
+test('read() should return empty object if load() rejects', (t) => {
+  const projectMeta = t.context.getTestSubject({
+    '@blinkmobile/blinkmrc': {
+      projectConfig: () => ({
+        load: () => Promise.reject()
+      })
+    }
+  })
+
+  return projectMeta.read(CWD)
+    .then((meta) => t.deepEqual(meta, {}))
+})
+
 test('read() should return contents of .blinkmrc.json file', (t) => {
   const projectMeta = t.context.getTestSubject()
 


### PR DESCRIPTION
### Changed

-   **BREAKING CHANGE**: `<project_path>` input option to a `--cwd` flag for all CLI commands

-   **BREAKING CHANGE**: `bm server scope --project <project>` now sets project using `bm server scope <project>`