### PR TITLE
SC-49 # Changed methods to ANY for serverless cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 -   SC-45: root route "/" has content instead of authorisation error
 
 
+### Changed
+
+-   SC-49: Changed methods from `DELETE`, `GET`, `OPTIONS`, `PATCH`, `POST` and `PUT`  to `ANY` when creating Serverless projects
+
+
 ## 1.0.0-beta.1 - 2016-12-19
 
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -26,7 +26,6 @@ const readRoutes = require('./routes/read.js')
 const scope = require('./scope.js')
 const updateYamlFile = require('./utils/yaml.js').updateYamlFile
 const validateCors = require('./cors/validate.js')
-const values = require('./values.js')
 
 const CPR_OPTIONS = {
   confirm: true,
@@ -144,9 +143,9 @@ function registerFunctions (
           const route = routeConfig.route.substr(1)
           const functionName = getFunctionName(index.toString(), env, cfg.project || '')
           functions[index] = {
-            events: values.METHODS.map((METHOD) => ({
-              http: `${METHOD} ${route}`
-            })),
+            events: [{
+              http: `ANY ${route}`
+            }],
             handler: `${HANDLER}.handler`,
             name: functionName,
             description: routeConfig.route


### PR DESCRIPTION
### Changed

-   SC-49: Changed methods from `DELETE`, `GET`, `OPTIONS`, `PATCH`, `POST` and `PUT`  to `ANY` when creating Serverless projects