### PR TITLE
SC-51 # Added VPC configuration support to `bm server serverless` cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
 
+## Unreleased
+
+
+### Added
+
+-   SC-51: `bm server serverless --vpc-security-groups --vpc-subnets` flags to specify Virtual Private Cloud configuration
+
+
 ## 1.0.0-beta.2 - 2017-01-11
 
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -70,7 +70,9 @@ const cli = meow({
     'env',
     'executionRole',
     'out',
-    'port'
+    'port',
+    'vpcSecurityGroups',
+    'vpcSubnets'
   ]
 })
 

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -10,6 +10,8 @@ module.exports = function (input, flags, logger, options) {
   const cwd = options.cwd
   const out = flags.out
   const env = flags.env
+  const vpcSecurityGroups = flags.vpcSecurityGroups
+  const vpcSubnets = flags.vpcSubnets
   const deploymentBucket = flags.deploymentBucket
   const executionRole = flags.executionRole
 
@@ -23,4 +25,5 @@ module.exports = function (input, flags, logger, options) {
     .then(() => lib.copyConfiguration(out, env))
     .then(() => lib.registerFunctions(out, env, deploymentBucket, executionRole))
     .then(() => lib.registerRootProxy(out, env))
+    .then(() => lib.registerVpc(out, vpcSecurityGroups, vpcSubnets, ','))
 }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -183,6 +183,30 @@ function registerRootProxy (
     }))
 }
 
+function registerVpc (
+  target /* : string */,
+  vpcSecurityGroups /* : string */,
+  vpcSubnets /* : string */,
+  separator /* : string */
+) /* : Promise<void> */ {
+  // Only add vpc configuration if security groups and subnets are provided
+  if (!vpcSecurityGroups || !vpcSubnets) {
+    return Promise.resolve()
+  }
+  const configPath = path.join(target, 'serverless.yml')
+
+  // https://serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration
+
+  return updateYamlFile(configPath, (config) => {
+    config.provider = config.provider || {}
+    config.provider.vpc = {
+      securityGroupIds: vpcSecurityGroups.split(separator).map((securityGroup) => securityGroup.trim()),
+      subnetIds: vpcSubnets.split(separator).map((subnet) => subnet.trim())
+    }
+    return config
+  })
+}
+
 module.exports = {
   applyTemplate,
   copyConfiguration,
@@ -194,5 +218,6 @@ module.exports = {
   getFunctionName,
   getRoutes,
   registerFunctions,
-  registerRootProxy
+  registerRootProxy,
+  registerVpc
 }

--- a/test/serverless.js
+++ b/test/serverless.js
@@ -37,11 +37,7 @@ test('registerVpc() should return config with vpc configuration added', (t) => {
       }
     }
   }
-  const serverless = t.context.getTestSubject({
-    './utils/yaml.js': {
-      updateYamlFile: (filePath, update) => Promise.resolve(update({}))
-    }
-  })
+  const serverless = t.context.getTestSubject()
   return serverless.registerVpc('.', '123, 456', 'abc, def', ',')
     .then((result) => t.deepEqual(result, expected))
 })

--- a/test/serverless.js
+++ b/test/serverless.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const test = require('ava')
+const proxyquire = require('proxyquire')
+
+const TEST_SUBJECT = '../lib/serverless.js'
+
+test.beforeEach((t) => {
+  t.context.getTestSubject = (overrides) => {
+    overrides = overrides || {}
+    return proxyquire(TEST_SUBJECT, Object.assign({
+      './utils/yaml.js': {
+        updateYamlFile: (filePath, update) => Promise.resolve(update({}))
+      }
+    }, overrides))
+  }
+})
+
+test('registerVpc() should return undefined if vpc configuation was not added', (t) => {
+  const serverless = t.context.getTestSubject()
+  return serverless.registerVpc()
+    .then((result) => t.falsy(result))
+})
+
+test('registerVpc() should return config with vpc configuration added', (t) => {
+  const expected = {
+    provider: {
+      vpc: {
+        securityGroupIds: [
+          '123',
+          '456'
+        ],
+        subnetIds: [
+          'abc',
+          'def'
+        ]
+      }
+    }
+  }
+  const serverless = t.context.getTestSubject({
+    './utils/yaml.js': {
+      updateYamlFile: (filePath, update) => Promise.resolve(update({}))
+    }
+  })
+  return serverless.registerVpc('.', '123, 456', 'abc, def', ',')
+    .then((result) => t.deepEqual(result, expected))
+})


### PR DESCRIPTION
### Added

-   SC-51: `bm server serverless --vpc-security-groups --vpc-subnets` flags to specify Virtual Private Cloud configuration
