### PR TITLE
SC-57 # View server logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   SC-55: timeout configuration for entire project (still defaults to 15 seconds), with an override at the route level
 
+-   SC-57: added `bm server logs` command to view server logs
+
 ## 1.0.0-beta.6 - 2017-03-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,22 +24,22 @@ Usage: blinkm server <command>
 
 Where command is one of:
 
-  info, serve, scope, deploy
+  info, serve, scope, deploy, logs
 
 Local development:
 
-  info                    => displays project information
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
-  serve                   => start a local development server using local API files
-    --port <port>         => sets the port to use for server, defaults to 3000
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
+  info                        => displays project information
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
+  serve                       => start a local development server using local API files
+    --port <port>             => sets the port to use for server, defaults to 3000
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
 
 Initial settings:
 
-  scope                   => displays the current scope
-    <project>             => sets the project id
-    --region <region>     => optionally sets the region
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
+  scope                       => displays the current scope
+    <project>                 => sets the project id
+    --region <region>         => optionally sets the region
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
 
 Deploying server side code:
 
@@ -47,10 +47,19 @@ Deploying server side code:
   For help on the login and logout commands please see:
   https://github.com/blinkmobile/identity-cli#usage
 
-  deploy                  => deploy the project
-    --force               => deploy without confirmation
-    --env <environment>   => optionally sets the environment to deploy to, defaults to 'dev'
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
+  deploy                      => deploy the project
+    --force                   => deploy without confirmation
+    --env <environment>       => optionally sets the environment to deploy to, defaults to 'dev'
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
+
+Viewing server logs:
+
+  logs <route>                => view logs for a specific route
+    --tail                    => keep listening for new logs in your terminal session
+    --filter <filterPattern>  => optionally set a search filter, defaults to all logs
+    --start-time <startTime>  => a unit in time to start fetching logs from (ie: 2010-10-20 or 1469705761), defaults to all logs
+    --env <environment>       => optionally set the environment to view logs for, defaults to 'dev'
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
 ```
 
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -101,7 +101,6 @@ Command not implemented: ${command}`))
 
 const input = cli.input.slice(1)
 const options = {
-  cwd: cli.flags.cwd,
   blinkMobileIdentity
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -23,7 +23,7 @@ Usage: blinkm server <command>
 
 Where command is one of:
 
-  info, serve, scope, deploy
+  info, serve, scope, deploy, logs
 
 Local development:
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -27,18 +27,18 @@ Where command is one of:
 
 Local development:
 
-  info                    => displays project information
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
-  serve                   => start a local development server using local API files
-    --port <port>         => sets the port to use for server, defaults to 3000
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
+  info                        => displays project information
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
+  serve                       => start a local development server using local API files
+    --port <port>             => sets the port to use for server, defaults to 3000
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
 
 Initial settings:
 
-  scope                   => displays the current scope
-    <project>             => sets the project id
-    --region <region>     => optionally sets the region
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
+  scope                       => displays the current scope
+    <project>                 => sets the project id
+    --region <region>         => optionally sets the region
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
 
 Deploying server side code:
 
@@ -46,10 +46,19 @@ Deploying server side code:
   For help on the login and logout commands please see:
   https://github.com/blinkmobile/identity-cli#usage
 
-  deploy                  => deploy the project
-    --force               => deploy without confirmation
-    --env <environment>   => optionally sets the environment to deploy to, defaults to 'dev'
-    --cwd <path>          => optionally set the path to project, defaults to current working directory
+  deploy                      => deploy the project
+    --force                   => deploy without confirmation
+    --env <environment>       => optionally sets the environment to deploy to, defaults to 'dev'
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
+
+Viewing server logs:
+
+  logs <route>                => view logs for a specific route
+    --tail                    => keep listening for new logs in your terminal session
+    --filter <filterPattern>  => optionally set a search filter, defaults to all logs
+    --start-time <startTime>  => a unit in time to start fetching logs from (ie: 2010-10-20 or 1469705761), defaults to all logs
+    --env <environment>       => optionally set the environment to view logs for, defaults to 'dev'
+    --cwd <path>              => optionally set the path to project, defaults to current working directory
 `
 
 const cli = meow({
@@ -57,22 +66,26 @@ const cli = meow({
   version: true
 }, {
   boolean: [
-    'force'
+    'force',
+    'tail'
   ],
   default: {
     'cwd': process.cwd(),
     'force': false,
     'env': 'dev',
-    'region': 'ap-southeast-2'
+    'region': 'ap-southeast-2',
+    'tail': false
   },
   string: [
     'deploymentBucket',
     'cwd',
     'env',
     'executionRole',
+    'filter',
     'out',
     'port',
     'region',
+    'startTime',
     'vpcSecurityGroups',
     'vpcSubnets'
   ]

--- a/bin/index.js
+++ b/bin/index.js
@@ -62,7 +62,8 @@ const cli = meow({
   default: {
     'cwd': process.cwd(),
     'force': false,
-    'env': 'dev'
+    'env': 'dev',
+    'region': 'ap-southeast-2'
   },
   string: [
     'deploymentBucket',
@@ -71,6 +72,7 @@ const cli = meow({
     'executionRole',
     'out',
     'port',
+    'region',
     'vpcSecurityGroups',
     'vpcSubnets'
   ]

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,9 +1,22 @@
+/* @flow */
 'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
 
 const info = require('./info.js')
 const deploy = require('../lib/deploy.js')
 
-module.exports = function (input, flags, logger, options) {
+module.exports = function (
+  input /* : Array<string> */,
+  flags /* : CLIFlags */,
+  logger /* : typeof console */,
+  options /* : CLIOptions */
+) /* : Promise<void> */ {
   const blinkMobileIdentity = options.blinkMobileIdentity
   const cwd = options.cwd
   const env = flags.env

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -18,7 +18,7 @@ module.exports = function (
   options /* : CLIOptions */
 ) /* : Promise<void> */ {
   const blinkMobileIdentity = options.blinkMobileIdentity
-  const cwd = options.cwd
+  const cwd = flags.cwd
   const env = flags.env
   const force = flags.force
   return info(input, flags, logger, options)

--- a/commands/info.js
+++ b/commands/info.js
@@ -1,10 +1,23 @@
+/* @flow */
 'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
 
 const displayCors = require('../lib/cors/display.js')
 const displayRoutes = require('../lib/routes/display.js')
 const scope = require('../lib/scope.js')
 
-module.exports = function (input, flags, logger, options) {
+module.exports = function (
+  input /* : Array<string> */,
+  flags /* : CLIFlags */,
+  logger /* : typeof console */,
+  options /* : CLIOptions */
+) /* : Promise<void> */ {
   const tasks = [
     () => scope.display(logger, options.cwd),
     () => displayCors(logger, options.cwd),

--- a/commands/info.js
+++ b/commands/info.js
@@ -19,9 +19,9 @@ module.exports = function (
   options /* : CLIOptions */
 ) /* : Promise<void> */ {
   const tasks = [
-    () => scope.display(logger, options.cwd),
-    () => displayCors(logger, options.cwd),
-    () => displayRoutes(logger, options.cwd)
+    () => scope.display(logger, flags.cwd),
+    () => displayCors(logger, flags.cwd),
+    () => displayRoutes(logger, flags.cwd)
   ]
   // Catch all errors and let all tasks run before
   // transforming into a single error

--- a/commands/logs.js
+++ b/commands/logs.js
@@ -1,0 +1,79 @@
+/* @flow */
+'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
+
+const pify = require('pify')
+const temp = require('temp').track()
+
+const getRouteConfig = require('../lib/routes/get-route-config')
+const scope = require('../lib/scope.js')
+const serverless = require('../lib/serverless.js')
+
+module.exports = function (
+  input /* : Array<string> */,
+  flags /* : CLIFlags */,
+  logger /* : typeof console */,
+  options /* : CLIOptions */
+) /* : Promise<void> */ {
+  const route = input[0]
+  if (!route) {
+    return Promise.reject(new Error('Must specify a route. E.g. bm server logs /route'))
+  }
+
+  return Promise.all([
+    scope.read(flags.cwd),
+    pify(temp.mkdir)('serverless')
+  ])
+    .then((results) => {
+      const cfg = results[0]
+      const tempDir = results[1]
+      return serverless.applyTemplate(tempDir)
+        .then(() => serverless.registerFunctions(tempDir, flags.cwd, flags.env))
+        .then(() => Promise.all([
+          getRouteConfig(flags.cwd, route),
+          options.blinkMobileIdentity.assumeAWSRole({
+            bmProject: cfg.project,
+            command: 'logs'
+          })
+        ]))
+        .then((results) => {
+          const routeConfig = results[0]
+          const credentials = results[1]
+          const args = [
+            'logs',
+            '--function',
+            serverless.getFunctionName(cfg, routeConfig, flags.env),
+            '--region',
+            cfg.region || flags.region,
+            '--stage',
+            flags.env
+          ]
+          if (flags.tail) {
+            args.push('--tail')
+          }
+          if (flags.filter) {
+            args.push('--filter', flags.filter)
+          }
+          if (flags.startTime) {
+            args.push('--startTime', flags.startTime)
+          }
+          const options = {
+            stdio: 'inherit',
+            cwd: tempDir,
+            env: Object.assign({}, process.env, {
+              AWS_ACCESS_KEY_ID: credentials.accessKeyId,
+              AWS_SECRET_ACCESS_KEY: credentials.secretAccessKey,
+              AWS_SESSION_TOKEN: credentials.sessionToken
+            })
+          }
+          return serverless.executeSLSCommand(args, options)
+            .catch(() => Promise.reject(new Error('See Severless Error above for more details.')))
+        })
+    })
+}

--- a/commands/scope.js
+++ b/commands/scope.js
@@ -1,20 +1,32 @@
+/* @flow */
 'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
 
 const scope = require('../lib/scope')
 
-const REGION = 'ap-southeast-2'
-
-module.exports = function (input, flags, logger, options) {
+module.exports = function (
+  input /* : Array<string> */,
+  flags /* : CLIFlags */,
+  logger /* : typeof console */,
+  options /* : CLIOptions */
+) /* : Promise<void> */ {
   const cwd = options.cwd
   const project = input[0]
-  const region = flags.region || REGION
-  let promise = Promise.resolve()
-  if (project) {
-    promise = scope.write(cwd, {
-      project,
-      region
+  const region = flags.region
+  return Promise.resolve()
+    .then(() => {
+      if (project) {
+        return scope.write(cwd, {
+          project,
+          region
+        })
+      }
     })
-  }
-  return promise
     .then(() => scope.display(logger, cwd))
 }

--- a/commands/scope.js
+++ b/commands/scope.js
@@ -16,7 +16,7 @@ module.exports = function (
   logger /* : typeof console */,
   options /* : CLIOptions */
 ) /* : Promise<void> */ {
-  const cwd = options.cwd
+  const cwd = flags.cwd
   const project = input[0]
   const region = flags.region
   return Promise.resolve()

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -21,7 +21,7 @@ module.exports = function (
   logger /* : typeof console */,
   options /* : CLIOptions */
 ) /* : Promise<void> */ {
-  const cwd = path.resolve(options.cwd)
+  const cwd = path.resolve(flags.cwd)
   const example = path.join('helloworld', 'index.js')
   return readCors(cwd)
     .then((cors) => serve.startServer({

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -1,4 +1,12 @@
+/* @flow */
 'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
 
 const path = require('path')
 
@@ -7,7 +15,12 @@ const chalk = require('chalk')
 const readCors = require('../lib/cors/read.js')
 const serve = require('../lib/serve.js')
 
-module.exports = function (input, flags, logger, options) {
+module.exports = function (
+  input /* : Array<string> */,
+  flags /* : CLIFlags */,
+  logger /* : typeof console */,
+  options /* : CLIOptions */
+) /* : Promise<void> */ {
   const cwd = path.resolve(options.cwd)
   const example = path.join('helloworld', 'index.js')
   return readCors(cwd)

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -20,7 +20,7 @@ module.exports = function (
   logger /* : typeof console */,
   options /* : CLIOptions */
 ) /* : Promise<void> */ {
-  const cwd = options.cwd
+  const cwd = flags.cwd
   const out = flags.out
   const env = flags.env
   const vpcSecurityGroups = flags.vpcSecurityGroups || ''

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -33,10 +33,14 @@ module.exports = function (
   }
 
   return lib.copyProject(cwd, out)
-    .then(() => lib.applyTemplate(out)) // TODO: eventually unnecessary?
-    .then(() => lib.copyWrapper(out))
-    .then(() => lib.copyConfiguration(out, env))
-    .then(() => lib.registerFunctions(out, env, deploymentBucket, executionRole))
-    .then(() => lib.registerRootProxy(out, env))
-    .then(() => lib.registerVpc(out, vpcSecurityGroups, vpcSubnets, ','))
+    .then((projectPath) => {
+      return lib.applyTemplate(out)
+        .then(() => lib.copyWrapper(out))
+        .then(() => lib.copyConfiguration(out, projectPath, env))
+        .then(() => lib.registerFunctions(out, projectPath, env))
+        .then(() => lib.registerDeploymentBucket(out, deploymentBucket))
+        .then(() => lib.registerExecutionRole(out, executionRole))
+        .then(() => lib.registerRootProxy(out, env))
+        .then(() => lib.registerVpc(out, vpcSecurityGroups, vpcSubnets, ','))
+    })
 }

--- a/commands/serverless.js
+++ b/commands/serverless.js
@@ -1,4 +1,12 @@
+/* @flow */
 'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
 
 /**
 bm serve serverless --input . --output /tmp/foobar
@@ -6,12 +14,17 @@ bm serve serverless --input . --output /tmp/foobar
 
 const lib = require('../lib/serverless.js')
 
-module.exports = function (input, flags, logger, options) {
+module.exports = function (
+  input /* : Array<string> */,
+  flags /* : CLIFlags */,
+  logger /* : typeof console */,
+  options /* : CLIOptions */
+) /* : Promise<void> */ {
   const cwd = options.cwd
   const out = flags.out
   const env = flags.env
-  const vpcSecurityGroups = flags.vpcSecurityGroups
-  const vpcSubnets = flags.vpcSubnets
+  const vpcSecurityGroups = flags.vpcSecurityGroups || ''
+  const vpcSubnets = flags.vpcSubnets || ''
   const deploymentBucket = flags.deploymentBucket
   const executionRole = flags.executionRole
 

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,68 @@
+# blinkmobile / server-cli
+
+## Logs
+
+Lets you view the logs of a specific route.
+
+```bash
+bm server logs /helloworld
+```
+
+**Note:** There's a small lag between invoking the function and actually having the log event registered. So it takes a few seconds for the logs to show up right after invoking the function.
+
+### Options
+
+-   `--env`: The environment you want to view the logs for.
+-   `--filter`: You can specify a filter string to filter the log output. This is useful if you want to to get the `error` logs for example. See [AWS - Filter and Pattern Syntax](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) for more advanced use of this flag.
+-   `--tail`: You can optionally tail the logs and keep listening for new logs in your terminal session by passing this option.
+-   `--start-time`: A specific unit in time to start fetching logs from (ie: `2010-10-20` or `1469705761`). Here's a list of the supported string formats:
+
+```bash
+30m                   # since 30 minutes ago
+2h                    # since 2 hours ago
+3d                    # since 3 days ago
+
+2013-02-08            # A calendar date part
+2013-W06-5            # A week date part
+2013-039              # An ordinal date part
+
+20130208              # Basic (short) full date
+2013W065              # Basic (short) week, weekday
+2013W06               # Basic (short) week only
+2013050               # Basic (short) ordinal date
+
+2013-02-08T09         # An hour time part separated by a T
+20130208T080910,123   # Short date and time up to ms, separated by comma
+20130208T080910.123   # Short date and time up to ms
+20130208T080910       # Short date and time up to seconds
+20130208T0809         # Short date and time up to minutes
+20130208T08           # Short date and time, hours only
+```
+
+### Examples
+
+-   View the logs that happened in the past 5 hours:
+
+    ```bash
+    bm server logs /helloworld --start-time 5h
+    ```
+
+-   View the logs that happened starting at epoch `1469694264`:
+
+    ```bash
+    bm server logs /helloworld --start-time 1469694264
+    ```
+
+-   Logs will be polled and the output will be logged to your terminal:
+
+    ```bash
+    bm server logs /helloworld --tail
+    ```
+
+    **Note**: Requires a `CTRL + C` to stop the polling.
+
+-   View only the logs that contain the string `CustomError`:
+
+    ```bash
+    bm server logs /helloworld --filter CustomError
+    ```

--- a/examples/configuration/.blinkmrc.json
+++ b/examples/configuration/.blinkmrc.json
@@ -5,21 +5,21 @@
     "cors": true,
     "routes": [
       {
-        "route": "/api/request",
+        "route": "/request",
         "module": "./api/request/index.js",
         "timeout": 5
       },
       {
-        "route": "/api/books",
+        "route": "/books",
         "module": "./api/books.js",
         "timeout": 5
       },
       {
-        "route": "/api/books/{id}",
+        "route": "/books/{id}",
         "module": "./api/book.js"
       },
       {
-        "route": "/api/books/{id}/chapters/{chapterNo}",
+        "route": "/books/{id}/chapters/{chapterNo}",
         "module": "./api/chapter.js"
       }
     ]

--- a/examples/directory/.blinkmrc.json
+++ b/examples/directory/.blinkmrc.json
@@ -2,7 +2,7 @@
   "server": {
     "project": "bm-example.api.blinkm.io",
     "region": "ap-southeast-2",
-    "cors": true,
+    "cors": false,
     "timeout": 5
   }
 }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -36,7 +36,10 @@ function authenticate (
 ) /* : Promise<BMServerAuthentication> */ {
   const stopUpdates = logUpdates(() => 'Authenticating...')
   return scope.read(cwd)
-    .then((config) => ({ bmProject: config.project }))
+    .then((config) => ({
+      bmProject: config.project,
+      command: 'deploy'
+    }))
     .then((parameters) => Promise.all([
       blinkMobileIdentity.assumeAWSRole(parameters),
       blinkMobileIdentity.getServiceSettings(parameters),

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -2,25 +2,16 @@
 'use strict'
 
 /* ::
-type AWSCredentials = {
-  accessKeyId : string,
-  secretAccessKey : string,
-  sessionToken : string
-}
-type BMServerSettings = {
-  analyticsKeys : any,
-  bucket : string,
-  region: string,
-  serviceOrigin : string
-}
-type BlinkMobileIdentity = {
-  assumeAWSRole : () => Promise<AWSCredentials>,
-  getServiceSettings : () => Promise<AWSCredentials>,
-  getAccessToken : () => Promise<string>
-}
+import type {
+  AWSCredentials,
+  BlinkMobileIdentity,
+  BMServerSettings
+} from '../types.js'
+
 type BMServerAuthentication = [
   AWSCredentials,
-  BMServerSettings
+  BMServerSettings,
+  string
 ]
 */
 
@@ -155,7 +146,7 @@ function upload (
   zipFilePath /* : string */,
   awsCredentials /* : AWSCredentials */,
   serviceSettings /* : BMServerSettings */
-) /* : Promise<void> */ {
+) /* : Promise<string> */ {
   const src = fs.createReadStream(zipFilePath)
   const key = path.basename(zipFilePath)
   const s3 = new AWS.S3(awsCredentials)

--- a/lib/routes/display.js
+++ b/lib/routes/display.js
@@ -1,6 +1,8 @@
 /* @flow */
 'use strict'
 
+const os = require('os')
+
 const Table = require('cli-table2')
 const chalk = require('chalk')
 
@@ -21,7 +23,7 @@ function displayRoutes (
       table.push([{
         content: chalk.bold('Route Configuration'),
         hAlign: 'center',
-        colSpan: 3
+        colSpan: 4
       }])
       const headings = ['Route', 'Module', 'Timeout (seconds)', 'Info']
       table.push(headings.map((heading) => (chalk.grey(heading))))
@@ -37,7 +39,7 @@ function displayRoutes (
             ]
             if (errors && errors.length) {
               totalErrors++
-              tableRow.push(chalk.red(errors.join('\n')))
+              tableRow.push(chalk.red(errors.join(os.EOL)))
             } else {
               tableRow.push(chalk.green('OK'))
             }

--- a/lib/routes/get-route-config.js
+++ b/lib/routes/get-route-config.js
@@ -1,0 +1,24 @@
+/* @flow */
+'use strict'
+
+/* ::
+import type {RouteConfiguration} from '../../types.js'
+*/
+
+const readRoutes = require('./read.js')
+
+function getRouteConfig (
+  cwd /* : string */,
+  route /* : string */
+) /* : Promise<RouteConfiguration> */ {
+  return readRoutes(cwd)
+    .then((routeConfigs) => {
+      const routeConfig = routeConfigs.find((rc) => rc.route === route)
+      if (!routeConfig) {
+        return Promise.reject(new Error(`Project does not contain route: ${route}`))
+      }
+      return routeConfig
+    })
+}
+
+module.exports = getRouteConfig

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -69,7 +69,7 @@ function startServer (
   options /* : {
     cors: CorsConfiguration | false,
     cwd: string,
-    port: number
+    port: string | number
   } */
 ) /* : Promise<any> */ {
   options = options || {}

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -27,7 +27,7 @@ const WRAPPER = path.join(__dirname, '..', 'dist', 'wrapper.js')
 function applyTemplate (
   cwd /* : string */
 ) /* : Promise<void> */ {
-  return execa(path.join(__dirname, '..', 'node_modules', '.bin', 'serverless'), [ 'create', '--template', 'aws-nodejs' ], { cwd })
+  return executeSLSCommand([ 'create', '--template', 'aws-nodejs' ], { cwd })
 }
 
 function copyConfiguration (
@@ -64,6 +64,13 @@ function copyWrapper (
 ) /* : Promise<void> */ {
   const wrapperPath = path.join(target, `${HANDLER}.js`)
   return copyRecursive(WRAPPER, wrapperPath)
+}
+
+function executeSLSCommand (
+  args /* : Array<string> */,
+  options /* : { [id:string]: any } */
+) /* : Promise<void> */ {
+  return execa(path.join(__dirname, '..', 'node_modules', '.bin', 'serverless'), args, options)
 }
 
 function getFunctionName (
@@ -196,6 +203,7 @@ module.exports = {
   copyConfiguration,
   copyProject,
   copyWrapper,
+  executeSLSCommand,
   getFunctionName,
   registerDeploymentBucket,
   registerExecutionRole,

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -5,19 +5,12 @@
 import type {
   BlinkMRCServer, CorsConfiguration, RouteConfiguration
 } from '../types.js'
-type ServerlessRouteConfiguration = {
-  functionName: string,
-  module: string,
-  route: string
-}
 */
 
 const path = require('path')
 
-const cpr = require('cpr')
 const execa = require('execa')
 const loadJsonFile = require('load-json-file')
-const pify = require('pify')
 const writeJsonFile = require('write-json-file')
 
 const nonAlphaNumericToDashes = require('./utils/non-alpha-numeric-to-dashes.js')
@@ -25,67 +18,45 @@ const readCors = require('./cors/read.js')
 const readRoutes = require('./routes/read.js')
 const scope = require('./scope.js')
 const updateYamlFile = require('./utils/yaml.js').updateYamlFile
+const copyRecursive = require('./utils/copy-recursive.js')
 const validateCors = require('./cors/validate.js')
 
-const CPR_OPTIONS = {
-  confirm: true,
-  deleteFirst: true,
-  overwrite: true
-}
 const HANDLER = 'handler'
 const WRAPPER = path.join(__dirname, '..', 'dist', 'wrapper.js')
 
 function applyTemplate (
   cwd /* : string */
 ) /* : Promise<void> */ {
-  return execa('serverless', [ 'create', '--template', 'aws-nodejs' ], { cwd })
+  return execa(path.join(__dirname, '..', 'node_modules', '.bin', 'serverless'), [ 'create', '--template', 'aws-nodejs' ], { cwd })
 }
 
 function copyConfiguration (
   target /* : string */,
+  projectPath /* : string */,
   env /* : string */
 ) /* : Promise<void> */ {
   const configPath = path.join(target, 'bm-server.json')
   return Promise.all([
-    getCors(target),
-    getRoutes(target, env)
+    readCors(projectPath)
+      .then((cors) => cors ? validateCors(cors) : false),
+    readRoutes(projectPath)
   ])
     .then((results) => writeJsonFile(configPath, {
       cors: results[0],
-      routes: results[1]
+      routes: results[1].map((routeConfig, index) => {
+        routeConfig.module = path.join(projectPath, routeConfig.module)
+        return routeConfig
+      })
     }))
 }
 
 function copyProject (
   source /* : string */,
   target /* : string */
-) /* : Promise<void> */ {
-  const projectPath = getProjectPath(target)
+) /* : Promise<string> */ {
+  const projectPath = path.join(target, 'project')
   return copyRecursive(source, projectPath)
-}
-
-function copyRecursive (
-  source /* : string */,
-  target /* : string */
-) /* : Promise<void> */ {
-  return pify(cpr)(source, target, CPR_OPTIONS)
-}
-
-function getRoutes (
-  target /* : string */,
-  env /* : string */
-) /* : Promise<Array<ServerlessRouteConfiguration>> */ {
-  const projectPath = getProjectPath(target)
-  return Promise.all([
-    readRoutes(projectPath),
-    scope.read(projectPath)
-  ])
-    .then((results) => results[0].map((routeConfig, index) => ({
-      // Set function name to allow for generic serverless wrapper to find module based on function name
-      functionName: getFunctionName(index.toString(), env, results[1].project || ''),
-      module: path.join('project', routeConfig.module),
-      route: routeConfig.route
-    })))
+    .then(() => projectPath)
 }
 
 function copyWrapper (
@@ -95,39 +66,22 @@ function copyWrapper (
   return copyRecursive(WRAPPER, wrapperPath)
 }
 
-function getProjectPath (
-  target /* : string */
-) /* : string */ {
-  return path.join(target, 'project')
-}
-
-function getCors (
-  target /* : string */
-) /* : Promise<CorsConfiguration | false> */ {
-  const projectPath = getProjectPath(target)
-  return readCors(projectPath)
-    .then((cors) => cors ? validateCors(cors) : false)
-}
-
 function getFunctionName (
-  route /* : string */,
-  env /* : string */,
-  project /* : string */
+  cfg /* : BlinkMRCServer */,
+  routeConfig /* : RouteConfiguration */,
+  env /* : string */
 ) /* : string */ {
   // Lambdas do not allow for any characters other than alpha-numeric and dashes in function names
-  const arr = [project, env, route]
+  const arr = [cfg.project || '', env, routeConfig.route]
   const mapped = arr.map(nonAlphaNumericToDashes)
   return mapped.join('-')
 }
 
 function registerFunctions (
   target /* : string */,
-  env /* : string */,
-  deploymentBucket /* : string | void */,
-  executionRole /* : string | void */
+  projectPath /* : string */,
+  env /* : string */
 ) /* : Promise<void> */ {
-  const configPath = path.join(target, 'serverless.yml')
-  const projectPath = getProjectPath(target)
   return Promise.all([
     readRoutes(projectPath),
     scope.read(projectPath)
@@ -136,22 +90,16 @@ function registerFunctions (
       const routeConfigs = results[0]
       const cfg = results[1]
 
-      return updateYamlFile(configPath, (config) => {
+      return updateServerlessYamlFile(target, (config) => {
         config.service = nonAlphaNumericToDashes(cfg.project || '')
         config.provider = config.provider || {}
         config.provider.region = cfg.region
         config.provider.stage = env
-        if (deploymentBucket) {
-          config.provider.deploymentBucket = deploymentBucket
-        }
-        if (executionRole) {
-          config.provider.role = executionRole
-        }
         config.functions = routeConfigs.reduce((functions, routeConfig, index) => {
           // The route must not start with a leading '/'
           const route = routeConfig.route.substr(1)
-          const functionName = getFunctionName(index.toString(), env, cfg.project || '')
-          functions[index] = {
+          const functionName = getFunctionName(cfg, routeConfig, env)
+          functions[functionName] = {
             events: [{
               http: `ANY ${route}`
             }],
@@ -168,18 +116,44 @@ function registerFunctions (
     })
 }
 
+function registerDeploymentBucket (
+  target /* : string */,
+  deploymentBucket /* : string | void */
+) /* : Promise<void> */ {
+  if (!deploymentBucket) {
+    return Promise.resolve()
+  }
+  return updateServerlessYamlFile(target, (config) => {
+    config.provider = config.provider || {}
+    config.provider.deploymentBucket = deploymentBucket
+    return config
+  })
+}
+
+function registerExecutionRole (
+  target /* : string */,
+  executionRole /* : string | void */
+) /* : Promise<void> */ {
+  if (!executionRole) {
+    return Promise.resolve()
+  }
+  return updateServerlessYamlFile(target, (config) => {
+    config.provider = config.provider || {}
+    config.provider.role = executionRole
+    return config
+  })
+}
+
 function registerRootProxy (
   target /* : string */,
   env /* : string */
 ) /* : Promise<void> */ {
   // TODO: detect root route Lambda function (if any) and skip this proxy
 
-  const configPath = path.join(target, 'serverless.yml')
-
   // https://serverless.com/framework/docs/providers/aws/events/apigateway#setting-an-http-proxy-on-api-gateway
 
   return loadJsonFile(path.join(__dirname, 'root-route-proxy.json'))
-    .then((resources) => updateYamlFile(configPath, (config) => {
+    .then((resources) => updateServerlessYamlFile(target, (config) => {
       config.resources = resources
       return config
     }))
@@ -187,38 +161,44 @@ function registerRootProxy (
 
 function registerVpc (
   target /* : string */,
-  vpcSecurityGroups /* : string */,
-  vpcSubnets /* : string */,
+  vpcSecurityGroups /* : string | void */,
+  vpcSubnets /* : string | void */,
   separator /* : string */
 ) /* : Promise<void> */ {
   // Only add vpc configuration if security groups and subnets are provided
   if (!vpcSecurityGroups || !vpcSubnets) {
     return Promise.resolve()
   }
-  const configPath = path.join(target, 'serverless.yml')
-
   // https://serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration
-
-  return updateYamlFile(configPath, (config) => {
-    config.provider = config.provider || {}
-    config.provider.vpc = {
-      securityGroupIds: vpcSecurityGroups.split(separator).map((securityGroup) => securityGroup.trim()),
-      subnetIds: vpcSubnets.split(separator).map((subnet) => subnet.trim())
+  return updateServerlessYamlFile(target, (config) => {
+    // need the extra check here incase things changed during updateServerlessYamlFile() (flow-type)
+    if (vpcSecurityGroups && vpcSubnets) {
+      config.provider = config.provider || {}
+      config.provider.vpc = {
+        securityGroupIds: vpcSecurityGroups.split(separator).map((securityGroup) => securityGroup.trim()),
+        subnetIds: vpcSubnets.split(separator).map((subnet) => subnet.trim())
+      }
     }
     return config
   })
+}
+
+function updateServerlessYamlFile (
+  target /* : string */,
+  updater /* : (data: Object) => Object */
+) /* : Promise<void> */ {
+  const configPath = path.join(target, 'serverless.yml')
+  return updateYamlFile(configPath, updater)
 }
 
 module.exports = {
   applyTemplate,
   copyConfiguration,
   copyProject,
-  copyRecursive,
   copyWrapper,
-  getCors,
-  getProjectPath,
   getFunctionName,
-  getRoutes,
+  registerDeploymentBucket,
+  registerExecutionRole,
   registerFunctions,
   registerRootProxy,
   registerVpc

--- a/lib/utils/copy-recursive.js
+++ b/lib/utils/copy-recursive.js
@@ -1,0 +1,20 @@
+/* @flow */
+'use strict'
+
+const cpr = require('cpr')
+const pify = require('pify')
+
+const CPR_OPTIONS = {
+  confirm: true,
+  deleteFirst: true,
+  overwrite: true
+}
+
+function copyRecursive (
+  source /* : string */,
+  target /* : string */
+) /* : Promise<void> */ {
+  return pify(cpr)(source, target, CPR_OPTIONS)
+}
+
+module.exports = copyRecursive

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "object-merge": "2.5.1",
     "pify": "2.3.0",
     "request": "2.81.0",
+    "serverless": "1.8.0",
     "temp": "0.8.3",
     "uniloc": "0.3.0",
     "update-notifier": "2.1.0",

--- a/test/apis.js
+++ b/test/apis.js
@@ -104,9 +104,9 @@ test('getRouteConfig() should reject if route cannot be found', (t) => {
 
 test('getRouteConfig() should find correct route and return route params', (t) => {
   const apis = t.context.getTestSubject()
-  return apis.getRouteConfig(CONFIGURATION_DIR, '/api/books/123/chapters/1')
+  return apis.getRouteConfig(CONFIGURATION_DIR, '/books/123/chapters/1')
     .then((routeConfig) => t.deepEqual(routeConfig, {
-      route: '/api/books/{id}/chapters/{chapterNo}',
+      route: '/books/{id}/chapters/{chapterNo}',
       module: path.resolve(CONFIGURATION_DIR, './api/chapter.js'),
       timeout: 15,
       params: {

--- a/test/fixtures/create-cli-flags.js
+++ b/test/fixtures/create-cli-flags.js
@@ -1,0 +1,19 @@
+/* @flow */
+'use strict'
+
+/* ::
+import type {CLIFlags} from '../../types.js'
+*/
+
+function createCLIFlags (
+  overrides /* : { [id:string]: string | boolean } | void */
+) /* : CLIFlags */ {
+  return Object.assign({
+    cwd: '.',
+    force: false,
+    env: 'dev',
+    region: 'ap-southeast-2'
+  }, overrides || {})
+}
+
+module.exports = createCLIFlags

--- a/test/fixtures/create-cli-flags.js
+++ b/test/fixtures/create-cli-flags.js
@@ -12,7 +12,8 @@ function createCLIFlags (
     cwd: '.',
     force: false,
     env: 'dev',
-    region: 'ap-southeast-2'
+    region: 'ap-southeast-2',
+    tail: false
   }, overrides || {})
 }
 

--- a/test/fixtures/serverless/examples/configuration.yml
+++ b/test/fixtures/serverless/examples/configuration.yml
@@ -1,0 +1,69 @@
+service: bm-example-api-blinkm-io
+provider:
+  name: aws
+  runtime: nodejs4.3
+  region: ap-southeast-2
+  stage: prod
+  deploymentBucket: deployment-bucket
+  role: execution-role
+  vpc:
+    securityGroupIds:
+      - '123'
+      - '456'
+    subnetIds:
+      - abc
+      - def
+functions:
+  bm-example-api-blinkm-io-prod--request:
+    events:
+      - http: ANY request
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-prod--request
+    description: /request
+    timeout: 5
+  bm-example-api-blinkm-io-prod--books:
+    events:
+      - http: ANY books
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-prod--books
+    description: /books
+    timeout: 5
+  bm-example-api-blinkm-io-prod--books--id-:
+    events:
+      - http: 'ANY books/{id}'
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-prod--books--id-
+    description: '/books/{id}'
+    timeout: 15
+  bm-example-api-blinkm-io-prod--books--id--chapters--chapterNo-:
+    events:
+      - http: 'ANY books/{id}/chapters/{chapterNo}'
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-prod--books--id--chapters--chapterNo-
+    description: '/books/{id}/chapters/{chapterNo}'
+    timeout: 15
+resources:
+  Resources:
+    ProxyMethod:
+      Type: 'AWS::ApiGateway::Method'
+      Properties:
+        AuthorizationType: NONE
+        ResourceId:
+          'Fn::GetAtt':
+            - ApiGatewayRestApi
+            - RootResourceId
+        RestApiId:
+          Ref: ApiGatewayRestApi
+        HttpMethod: GET
+        MethodResponses:
+          - ResponseParameters:
+              method.response.header.Content-Type: integration.response.header.Content-Type
+            StatusCode: 200
+        Integration:
+          IntegrationHttpMethod: GET
+          Type: HTTP
+          Uri: 'https://blinkmobile.github.io/server-cli/root-route.html'
+          IntegrationResponses:
+            - ResponseParameters:
+                method.response.header.Content-Type: integration.response.header.Content-Type
+              StatusCode: 200

--- a/test/fixtures/serverless/examples/directory.yml
+++ b/test/fixtures/serverless/examples/directory.yml
@@ -1,0 +1,74 @@
+service: bm-example-api-blinkm-io
+provider:
+  name: aws
+  runtime: nodejs4.3
+  region: ap-southeast-2
+  stage: test
+functions:
+  bm-example-api-blinkm-io-test--boom:
+    events:
+      - http: ANY boom
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-test--boom
+    description: /boom
+    timeout: 15
+  bm-example-api-blinkm-io-test--helloworld:
+    events:
+      - http: ANY helloworld
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-test--helloworld
+    description: /helloworld
+    timeout: 15
+  bm-example-api-blinkm-io-test--methods:
+    events:
+      - http: ANY methods
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-test--methods
+    description: /methods
+    timeout: 15
+  bm-example-api-blinkm-io-test--promise:
+    events:
+      - http: ANY promise
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-test--promise
+    description: /promise
+    timeout: 15
+  bm-example-api-blinkm-io-test--request:
+    events:
+      - http: ANY request
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-test--request
+    description: /request
+    timeout: 15
+  bm-example-api-blinkm-io-test--response:
+    events:
+      - http: ANY response
+    handler: handler.handler
+    name: bm-example-api-blinkm-io-test--response
+    description: /response
+    timeout: 15
+resources:
+  Resources:
+    ProxyMethod:
+      Type: 'AWS::ApiGateway::Method'
+      Properties:
+        AuthorizationType: NONE
+        ResourceId:
+          'Fn::GetAtt':
+            - ApiGatewayRestApi
+            - RootResourceId
+        RestApiId:
+          Ref: ApiGatewayRestApi
+        HttpMethod: GET
+        MethodResponses:
+          - ResponseParameters:
+              method.response.header.Content-Type: integration.response.header.Content-Type
+            StatusCode: 200
+        Integration:
+          IntegrationHttpMethod: GET
+          Type: HTTP
+          Uri: 'https://blinkmobile.github.io/server-cli/root-route.html'
+          IntegrationResponses:
+            - ResponseParameters:
+                method.response.header.Content-Type: integration.response.header.Content-Type
+              StatusCode: 200

--- a/test/logs.js
+++ b/test/logs.js
@@ -1,0 +1,91 @@
+/* @flow */
+'use strict'
+
+/* ::
+import type {
+  CLIFlags,
+  CLIOptions
+} from '../types.js'
+*/
+
+const path = require('path')
+
+const test = require('ava')
+const proxyquire /* : (string, { [id:string]: any }) => (Array<string>, CLIFlags, typeof console, CLIOptions) => Promise<void> */ = require('proxyquire')
+
+const createCliFlags = require('./fixtures/create-cli-flags.js')
+
+const DIRECTORY_DIR = path.join(__dirname, '../examples/directory')
+const CLI_OPTIONS = {
+  blinkMobileIdentity: {
+    assumeAWSRole: () => Promise.resolve({
+      accessKeyId: 'access key id',
+      secretAccessKey: 'secret access key',
+      sessionToken: 'session token'
+    }),
+    getAccessToken: () => Promise.resolve('access token'),
+    getServiceSettings: () => Promise.resolve({
+      bucket: 's3 bucket',
+      serviceOrigin: 'http service origin'
+    })
+  }
+}
+
+test('should reject if a route is not specified', (t) => {
+  const logs = require('../commands/logs.js')
+  t.throws(
+    logs([], createCliFlags(), console, CLI_OPTIONS),
+    'Must specify a route. E.g. bm server logs /route'
+  )
+})
+
+test('should call "serverless logs" with correct arguments and options', (t) => {
+  t.plan(5)
+  const logs = proxyquire('../commands/logs.js', {
+    '../lib/serverless.js': {
+      executeSLSCommand: (args, options) => {
+        t.deepEqual(args, [
+          'logs',
+          '--function',
+          'bm-example-api-blinkm-io-prod--request',
+          '--region',
+          'ap-southeast-2',
+          '--stage',
+          'prod',
+          '--tail',
+          '--filter',
+          'my custom filter',
+          '--startTime',
+          '2016'
+        ])
+        t.is(options.stdio, 'inherit')
+        t.is(options.env.AWS_ACCESS_KEY_ID, 'access key id')
+        t.is(options.env.AWS_SECRET_ACCESS_KEY, 'secret access key')
+        t.is(options.env.AWS_SESSION_TOKEN, 'session token')
+        return Promise.resolve()
+      }
+    }
+  })
+  return logs(['/request'], createCliFlags({
+    cwd: DIRECTORY_DIR,
+    env: 'prod',
+    tail: true,
+    filter: 'my custom filter',
+    startTime: '2016'
+  }), console, CLI_OPTIONS)
+})
+
+test('should reject if "serverless logs" fails', (t) => {
+  const logs = proxyquire('../commands/logs.js', {
+    '../lib/serverless.js': {
+      executeSLSCommand: (args, options) => Promise.reject(new Error('error message'))
+    }
+  })
+  t.throws(
+    logs(['/request'], createCliFlags({
+      cwd: DIRECTORY_DIR,
+      env: 'prod'
+    }), console, CLI_OPTIONS),
+    'See Severless Error above for more details.'
+  )
+})

--- a/test/routes/get-route-config.js
+++ b/test/routes/get-route-config.js
@@ -1,0 +1,44 @@
+/* @flow */
+'use strict'
+
+const test = require('ava')
+const proxyquire = require('proxyquire')
+
+const TEST_SUBJECT = '../../lib/routes/get-route-config.js'
+
+const CWD = 'current working directory'
+const ROUTES = [
+  {
+    'route': '/',
+    'module': './api/root.js'
+  },
+  {
+    'route': '/api/books/:id',
+    'module': './api/book.js'
+  },
+  {
+    'route': '/api/books',
+    'module': 'api/books.js'
+  }
+]
+
+function getTestSubject (overrides) {
+  overrides = overrides || {}
+  return proxyquire(TEST_SUBJECT, Object.assign({
+    './read.js': () => Promise.resolve(ROUTES)
+  }, overrides))
+}
+
+test('should return route config', (t) => {
+  const lib = getTestSubject()
+  return lib(CWD, '/api/books/:id')
+    .then((routeConfig) => t.deepEqual(routeConfig, ROUTES[1]))
+})
+
+test('should reject if a project does not contain route', (t) => {
+  const lib = getTestSubject()
+  t.throws(
+    lib(CWD, '/route'),
+    'Project does not contain route: /route'
+  )
+})

--- a/test/serverless.js
+++ b/test/serverless.js
@@ -28,7 +28,6 @@ test('should produce the expected serverless.yml for configuration example proje
         vpcSecurityGroups: '123, 456',
         vpcSubnets: 'abc, def'
       }), console, {
-        cwd: CONFIGURATION_DIR,
         blinkMobileIdentity: new BlinkMobileIdentity()
       })
         .then(() => {
@@ -49,7 +48,6 @@ test('should produce the expected serverless.yml for directory example project',
         env: 'test',
         out: tempDir
       }), console, {
-        cwd: DIRECTORY_DIR,
         blinkMobileIdentity: new BlinkMobileIdentity()
       })
         .then(() => {
@@ -64,7 +62,6 @@ test('should produce the expected serverless.yml for directory example project',
 
 test('should reject if --out flag is falsey', (t) => {
   t.throws(serverless([], createCliFlags(), console, {
-    cwd: CONFIGURATION_DIR,
     blinkMobileIdentity: new BlinkMobileIdentity()
   }), '"--out" is mandatory')
 })

--- a/test/utils/project-meta.js
+++ b/test/utils/project-meta.js
@@ -65,7 +65,4 @@ test('write() should merge changes with .blinkmrc.json file', (t) => {
       'new': 'test new property',
       'project-meta': 'test'
     }))
-    .then(() => projectMeta.write(CWD, (config) => ({
-      'project-meta': 'test'
-    })))
 })

--- a/types.js
+++ b/types.js
@@ -6,6 +6,18 @@ import type BmResponse from './lib/bm-response.js'
 */
 
 /* ::
+export type AWSCredentials = {
+  accessKeyId : string,
+  secretAccessKey : string,
+  sessionToken : string
+}
+
+export type BlinkMobileIdentity = {
+  assumeAWSRole : () => Promise<AWSCredentials>,
+  getServiceSettings : () => Promise<BMServerSettings>,
+  getAccessToken : () => Promise<string>
+}
+
 export type BlinkMRC = {
   server?: BlinkMRCServer
 }
@@ -16,6 +28,13 @@ export type BlinkMRCServer = {
   cors?: CorsConfiguration | boolean,
   routes?: Array<RouteConfiguration>,
   timeout?: number
+}
+
+export type BMServerSettings = {
+  analyticsKeys : any,
+  bucket : string,
+  region: string,
+  serviceOrigin : string
 }
 
 export type BmRequest = {
@@ -30,6 +49,24 @@ export type BmRequest = {
     protocol: Protocol,
     query: { [id:string]: string }
   }
+}
+
+export type CLIFlags = {
+  deploymentBucket?: string,
+  cwd: string,
+  env: string,
+  executionRole?: string,
+  force: boolean,
+  out?: string,
+  port?: string,
+  region: string,
+  vpcSecurityGroups?: string,
+  vpcSubnets?: string
+}
+
+export type CLIOptions = {
+  cwd: string,
+  blinkMobileIdentity: BlinkMobileIdentity
 }
 
 export type CorsConfiguration = {

--- a/types.js
+++ b/types.js
@@ -65,7 +65,6 @@ export type CLIFlags = {
 }
 
 export type CLIOptions = {
-  cwd: string,
   blinkMobileIdentity: BlinkMobileIdentity
 }
 

--- a/types.js
+++ b/types.js
@@ -31,9 +31,7 @@ export type BlinkMRCServer = {
 }
 
 export type BMServerSettings = {
-  analyticsKeys : any,
   bucket : string,
-  region: string,
   serviceOrigin : string
 }
 
@@ -56,10 +54,13 @@ export type CLIFlags = {
   cwd: string,
   env: string,
   executionRole?: string,
+  filter?: string,
   force: boolean,
   out?: string,
   port?: string,
   region: string,
+  startTime?: string,
+  tail: boolean,
   vpcSecurityGroups?: string,
   vpcSubnets?: string
 }


### PR DESCRIPTION
### Added

-   SC-57: added `bm server logs` command to view server logs

### Code Review Notes

-   Should be easier to review one commit at a time
-   Out `bm server logs` cmd will internally call `serverless logs`
     -   `serverless@1.8.0` is now a dependency
-   Lambda function names that are deployed using `bm server serverless` have changed to accomadate for the [breaking changes introduced in `serverless@1.6.0`](https://github.com/serverless/serverless/releases/tag/v1.6.0). Changing the function name will mean new log groups are created instead of having to delete the existing log groups.