### PR TITLE
SC-71 # Single set of AWS resources per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   SC-71: `bm server serverless` now creates one set of AWS resources (Lambda, API Gateway Endpoint and Log Group) for all routes in a project instead of one set for each route.
 
+### Removed
+
+-   SC-71: timeout override at the route level. All routes will now share the same timeout.
+
 ## 1.0.0 - 2017-03-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   SC-71: `bm server serverless` now creates one set of AWS resources (Lambda, API Gateway Endpoint and Log Group) for all routes in a project instead of one set for each route.
+
 ## 1.0.0 - 2017-03-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   SC-71: `route` property to `request` argument passed to handlers. Will contain the original `route` property.
+
 ### Changed
 
 -   SC-71: `bm server serverless` now creates one set of AWS resources (Lambda, API Gateway Endpoint and Log Group) for all routes in a project instead of one set for each route.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Removed
 
+-   SC-71: `/route` input from `bm server logs /route`. Logs will now be retrieved for all routes in the project.
 -   SC-71: timeout override at the route level. All routes will now share the same timeout.
 
 ## 1.0.0 - 2017-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   SC-71: `route` property to `request` argument passed to handlers. Will contain the original `route` property.
+-   SC-71: analytics log message to wrapper to allow for metrics and analysis on routes
 
 ### Changed
 

--- a/dist/wrapper.js
+++ b/dist/wrapper.js
@@ -64,9 +64,13 @@ module.exports = BmResponse
 /* ::
 import type {
   Handler,
-  BmRequest
+  BmRequest,
+  RouteConfiguration
 } from '../types.js'
 */
+
+const uniloc = require('uniloc')
+
 const BmResponse = require('../lib/bm-response.js')
 
 function executeHandler (
@@ -107,12 +111,33 @@ function getHandler (
   }
 }
 
+function findRouteConfig (
+  route /* : string */,
+  routeConfigs /* : RouteConfiguration[] */
+) /* : RouteConfiguration */ {
+  const unilocRoutes = routeConfigs.reduce((memo, r) => {
+    memo[r.route] = `GET ${r.route.replace(/{/g, ':').replace(/}/g, '')}`
+    return memo
+  }, {})
+  const unilocRouter = uniloc(unilocRoutes)
+  const unilocRoute = unilocRouter.lookup(route, 'GET')
+
+  const routeConfig = routeConfigs.find((routeConfig) => routeConfig.route === unilocRoute.name)
+  if (!routeConfig) {
+    throw new Error(`Route has not been implemented: ${route}`)
+  }
+
+  routeConfig.params = unilocRoute.options
+  return routeConfig
+}
+
 module.exports = {
+  findRouteConfig,
   executeHandler,
   getHandler
 }
 
-},{"../lib/bm-response.js":1}],3:[function(require,module,exports){
+},{"../lib/bm-response.js":1,"uniloc":5}],3:[function(require,module,exports){
 /* @flow */
 
 /* :: import type { MapObject } from '../../types.js' */
@@ -191,1855 +216,237 @@ module.exports = {
 }
 
 },{}],5:[function(require,module,exports){
-'use strict';
-
-var util = require('util');
-var isArrayish = require('is-arrayish');
-
-var errorEx = function errorEx(name, properties) {
-	if (!name || name.constructor !== String) {
-		properties = name || {};
-		name = Error.name;
-	}
-
-	var errorExError = function ErrorEXError(message) {
-		if (!this) {
-			return new ErrorEXError(message);
-		}
-
-		message = message instanceof Error
-			? message.message
-			: (message || this.message);
-
-		Error.call(this, message);
-		Error.captureStackTrace(this, errorExError);
-
-		this.name = name;
-
-		Object.defineProperty(this, 'message', {
-			configurable: true,
-			enumerable: false,
-			get: function () {
-				var newMessage = message.split(/\r?\n/g);
-
-				for (var key in properties) {
-					if (!properties.hasOwnProperty(key)) {
-						continue;
-					}
-
-					var modifier = properties[key];
-
-					if ('message' in modifier) {
-						newMessage = modifier.message(this[key], newMessage) || newMessage;
-						if (!isArrayish(newMessage)) {
-							newMessage = [newMessage];
-						}
-					}
-				}
-
-				return newMessage.join('\n');
-			},
-			set: function (v) {
-				message = v;
-			}
-		});
-
-		var stackDescriptor = Object.getOwnPropertyDescriptor(this, 'stack');
-		var stackGetter = stackDescriptor.get;
-		var stackValue = stackDescriptor.value;
-		delete stackDescriptor.value;
-		delete stackDescriptor.writable;
-
-		stackDescriptor.get = function () {
-			var stack = (stackGetter)
-				? stackGetter.call(this).split(/\r?\n+/g)
-				: stackValue.split(/\r?\n+/g);
-
-			// starting in Node 7, the stack builder caches the message.
-			// just replace it.
-			stack[0] = this.name + ': ' + this.message;
-
-			var lineCount = 1;
-			for (var key in properties) {
-				if (!properties.hasOwnProperty(key)) {
-					continue;
-				}
-
-				var modifier = properties[key];
-
-				if ('line' in modifier) {
-					var line = modifier.line(this[key]);
-					if (line) {
-						stack.splice(lineCount++, 0, '    ' + line);
-					}
-				}
-
-				if ('stack' in modifier) {
-					modifier.stack(this[key], stack);
-				}
-			}
-
-			return stack.join('\n');
-		};
-
-		Object.defineProperty(this, 'stack', stackDescriptor);
-	};
-
-	if (Object.setPrototypeOf) {
-		Object.setPrototypeOf(errorExError.prototype, Error.prototype);
-		Object.setPrototypeOf(errorExError, Error);
-	} else {
-		util.inherits(errorExError, Error);
-	}
-
-	return errorExError;
-};
-
-errorEx.append = function (str, def) {
-	return {
-		message: function (v, message) {
-			v = v || def;
-
-			if (v) {
-				message[0] += ' ' + str.replace('%s', v.toString());
-			}
-
-			return message;
-		}
-	};
-};
-
-errorEx.line = function (str, def) {
-	return {
-		line: function (v) {
-			v = v || def;
-
-			if (v) {
-				return str.replace('%s', v.toString());
-			}
-
-			return null;
-		}
-	};
-};
-
-module.exports = errorEx;
-
-},{"is-arrayish":10,"util":undefined}],6:[function(require,module,exports){
-'use strict'
-
-var fs = require('fs')
-
-module.exports = clone(fs)
-
-function clone (obj) {
-  if (obj === null || typeof obj !== 'object')
-    return obj
-
-  if (obj instanceof Object)
-    var copy = { __proto__: obj.__proto__ }
-  else
-    var copy = Object.create(null)
-
-  Object.getOwnPropertyNames(obj).forEach(function (key) {
-    Object.defineProperty(copy, key, Object.getOwnPropertyDescriptor(obj, key))
-  })
-
-  return copy
-}
-
-},{"fs":undefined}],7:[function(require,module,exports){
-var fs = require('fs')
-var polyfills = require('./polyfills.js')
-var legacy = require('./legacy-streams.js')
-var queue = []
-
-var util = require('util')
-
-function noop () {}
-
-var debug = noop
-if (util.debuglog)
-  debug = util.debuglog('gfs4')
-else if (/\bgfs4\b/i.test(process.env.NODE_DEBUG || ''))
-  debug = function() {
-    var m = util.format.apply(util, arguments)
-    m = 'GFS4: ' + m.split(/\n/).join('\nGFS4: ')
-    console.error(m)
-  }
-
-if (/\bgfs4\b/i.test(process.env.NODE_DEBUG || '')) {
-  process.on('exit', function() {
-    debug(queue)
-    require('assert').equal(queue.length, 0)
-  })
-}
-
-module.exports = patch(require('./fs.js'))
-if (process.env.TEST_GRACEFUL_FS_GLOBAL_PATCH) {
-  module.exports = patch(fs)
-}
-
-// Always patch fs.close/closeSync, because we want to
-// retry() whenever a close happens *anywhere* in the program.
-// This is essential when multiple graceful-fs instances are
-// in play at the same time.
-module.exports.close =
-fs.close = (function (fs$close) { return function (fd, cb) {
-  return fs$close.call(fs, fd, function (err) {
-    if (!err)
-      retry()
-
-    if (typeof cb === 'function')
-      cb.apply(this, arguments)
-  })
-}})(fs.close)
-
-module.exports.closeSync =
-fs.closeSync = (function (fs$closeSync) { return function (fd) {
-  // Note that graceful-fs also retries when fs.closeSync() fails.
-  // Looks like a bug to me, although it's probably a harmless one.
-  var rval = fs$closeSync.apply(fs, arguments)
-  retry()
-  return rval
-}})(fs.closeSync)
-
-function patch (fs) {
-  // Everything that references the open() function needs to be in here
-  polyfills(fs)
-  fs.gracefulify = patch
-  fs.FileReadStream = ReadStream;  // Legacy name.
-  fs.FileWriteStream = WriteStream;  // Legacy name.
-  fs.createReadStream = createReadStream
-  fs.createWriteStream = createWriteStream
-  var fs$readFile = fs.readFile
-  fs.readFile = readFile
-  function readFile (path, options, cb) {
-    if (typeof options === 'function')
-      cb = options, options = null
-
-    return go$readFile(path, options, cb)
-
-    function go$readFile (path, options, cb) {
-      return fs$readFile(path, options, function (err) {
-        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$readFile, [path, options, cb]])
-        else {
-          if (typeof cb === 'function')
-            cb.apply(this, arguments)
-          retry()
-        }
-      })
+(function(root) {
+  function assert(condition, format) {
+    if (!condition) {
+      var args = [].slice.call(arguments, 2);
+      var argIndex = 0;
+      throw new Error(
+        'Unirouter Assertion Failed: ' +
+        format.replace(/%s/g, function() { return args[argIndex++]; })
+      );
     }
   }
 
-  var fs$writeFile = fs.writeFile
-  fs.writeFile = writeFile
-  function writeFile (path, data, options, cb) {
-    if (typeof options === 'function')
-      cb = options, options = null
-
-    return go$writeFile(path, data, options, cb)
-
-    function go$writeFile (path, data, options, cb) {
-      return fs$writeFile(path, data, options, function (err) {
-        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$writeFile, [path, data, options, cb]])
-        else {
-          if (typeof cb === 'function')
-            cb.apply(this, arguments)
-          retry()
-        }
-      })
-    }
+  function pathParts(path) {
+    return path == '' ? [] : path.split('/')
   }
 
-  var fs$appendFile = fs.appendFile
-  if (fs$appendFile)
-    fs.appendFile = appendFile
-  function appendFile (path, data, options, cb) {
-    if (typeof options === 'function')
-      cb = options, options = null
+  function routeParts(route) {
+    var split = route.split(/\s+/)
+    var method = split[0]
+    var path = split[1]
 
-    return go$appendFile(path, data, options, cb)
+    // Validate route format
+    assert(
+      split.length == 2,
+      "Route `%s` separates method and path with a single block of whitespace", route
+    )
 
-    function go$appendFile (path, data, options, cb) {
-      return fs$appendFile(path, data, options, function (err) {
-        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$appendFile, [path, data, options, cb]])
-        else {
-          if (typeof cb === 'function')
-            cb.apply(this, arguments)
-          retry()
-        }
-      })
-    }
+    // Validate method format
+    assert(
+      /^[A-Z]+$/.test(method),
+      "Route `%s` starts with an UPPERCASE method", route
+    )
+
+    // Validate path format
+    assert(
+      !/\/{2,}/.test(path),
+      "Path `%s` has no adjacent `/` characters: `%s`", path
+    )
+    assert(
+      path[0] == '/',
+      "Path `%s` must start with the `/` character", path
+    )
+    assert(
+      path == '/' || !/\/$/.test(path),
+      "Path `%s` does not end with the `/` character", path
+    )
+    assert(
+      path.indexOf('#') === -1 && path.indexOf('?') === -1,
+      "Path `%s` does not contain the `#` or `?` characters", path
+    )
+
+    return pathParts(path.slice(1)).concat(method)
   }
 
-  var fs$readdir = fs.readdir
-  fs.readdir = readdir
-  function readdir (path, options, cb) {
-    var args = [path]
-    if (typeof options !== 'function') {
-      args.push(options)
-    } else {
-      cb = options
-    }
-    args.push(go$readdir$cb)
 
-    return go$readdir(args)
+  function LookupTree() {
+    this.tree = {}
+  }
 
-    function go$readdir$cb (err, files) {
-      if (files && files.sort)
-        files.sort()
+  function lookupTreeReducer(tree, part) {
+    return tree && (tree[part] || tree[':'])
+  }
 
-      if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-        enqueue([go$readdir, [args]])
-      else {
-        if (typeof cb === 'function')
-          cb.apply(this, arguments)
-        retry()
+  LookupTree.prototype.find = function(parts) {
+    return (parts.reduce(lookupTreeReducer, this.tree) || {})['']
+  }
+
+  LookupTree.prototype.add = function(parts, route) {
+    var i, branch
+    var branches = parts.map(function(part) { return part[0] == ':' ? ':' : part })
+    var currentTree = this.tree
+
+    for (i = 0; i < branches.length; i++) {
+      branch = branches[i]  
+      if (!currentTree[branch]) {
+        currentTree[branch] = {}
       }
-    }
-  }
-
-  function go$readdir (args) {
-    return fs$readdir.apply(fs, args)
-  }
-
-  if (process.version.substr(0, 4) === 'v0.8') {
-    var legStreams = legacy(fs)
-    ReadStream = legStreams.ReadStream
-    WriteStream = legStreams.WriteStream
-  }
-
-  var fs$ReadStream = fs.ReadStream
-  ReadStream.prototype = Object.create(fs$ReadStream.prototype)
-  ReadStream.prototype.open = ReadStream$open
-
-  var fs$WriteStream = fs.WriteStream
-  WriteStream.prototype = Object.create(fs$WriteStream.prototype)
-  WriteStream.prototype.open = WriteStream$open
-
-  fs.ReadStream = ReadStream
-  fs.WriteStream = WriteStream
-
-  function ReadStream (path, options) {
-    if (this instanceof ReadStream)
-      return fs$ReadStream.apply(this, arguments), this
-    else
-      return ReadStream.apply(Object.create(ReadStream.prototype), arguments)
-  }
-
-  function ReadStream$open () {
-    var that = this
-    open(that.path, that.flags, that.mode, function (err, fd) {
-      if (err) {
-        if (that.autoClose)
-          that.destroy()
-
-        that.emit('error', err)
-      } else {
-        that.fd = fd
-        that.emit('open', fd)
-        that.read()
-      }
-    })
-  }
-
-  function WriteStream (path, options) {
-    if (this instanceof WriteStream)
-      return fs$WriteStream.apply(this, arguments), this
-    else
-      return WriteStream.apply(Object.create(WriteStream.prototype), arguments)
-  }
-
-  function WriteStream$open () {
-    var that = this
-    open(that.path, that.flags, that.mode, function (err, fd) {
-      if (err) {
-        that.destroy()
-        that.emit('error', err)
-      } else {
-        that.fd = fd
-        that.emit('open', fd)
-      }
-    })
-  }
-
-  function createReadStream (path, options) {
-    return new ReadStream(path, options)
-  }
-
-  function createWriteStream (path, options) {
-    return new WriteStream(path, options)
-  }
-
-  var fs$open = fs.open
-  fs.open = open
-  function open (path, flags, mode, cb) {
-    if (typeof mode === 'function')
-      cb = mode, mode = null
-
-    return go$open(path, flags, mode, cb)
-
-    function go$open (path, flags, mode, cb) {
-      return fs$open(path, flags, mode, function (err, fd) {
-        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$open, [path, flags, mode, cb]])
-        else {
-          if (typeof cb === 'function')
-            cb.apply(this, arguments)
-          retry()
-        }
-      })
-    }
-  }
-
-  return fs
-}
-
-function enqueue (elem) {
-  debug('ENQUEUE', elem[0].name, elem[1])
-  queue.push(elem)
-}
-
-function retry () {
-  var elem = queue.shift()
-  if (elem) {
-    debug('RETRY', elem[0].name, elem[1])
-    elem[0].apply(null, elem[1])
-  }
-}
-
-},{"./fs.js":6,"./legacy-streams.js":8,"./polyfills.js":9,"assert":undefined,"fs":undefined,"util":undefined}],8:[function(require,module,exports){
-var Stream = require('stream').Stream
-
-module.exports = legacy
-
-function legacy (fs) {
-  return {
-    ReadStream: ReadStream,
-    WriteStream: WriteStream
-  }
-
-  function ReadStream (path, options) {
-    if (!(this instanceof ReadStream)) return new ReadStream(path, options);
-
-    Stream.call(this);
-
-    var self = this;
-
-    this.path = path;
-    this.fd = null;
-    this.readable = true;
-    this.paused = false;
-
-    this.flags = 'r';
-    this.mode = 438; /*=0666*/
-    this.bufferSize = 64 * 1024;
-
-    options = options || {};
-
-    // Mixin options into this
-    var keys = Object.keys(options);
-    for (var index = 0, length = keys.length; index < length; index++) {
-      var key = keys[index];
-      this[key] = options[key];
+      currentTree = currentTree[branch]
     }
 
-    if (this.encoding) this.setEncoding(this.encoding);
+    assert(
+      !currentTree[branch],
+      "Path `%s` conflicts with another path", parts.join('/')
+    )
 
-    if (this.start !== undefined) {
-      if ('number' !== typeof this.start) {
-        throw TypeError('start must be a Number');
-      }
-      if (this.end === undefined) {
-        this.end = Infinity;
-      } else if ('number' !== typeof this.end) {
-        throw TypeError('end must be a Number');
-      }
-
-      if (this.start > this.end) {
-        throw new Error('start must be <= end');
-      }
-
-      this.pos = this.start;
-    }
-
-    if (this.fd !== null) {
-      process.nextTick(function() {
-        self._read();
-      });
-      return;
-    }
-
-    fs.open(this.path, this.flags, this.mode, function (err, fd) {
-      if (err) {
-        self.emit('error', err);
-        self.readable = false;
-        return;
-      }
-
-      self.fd = fd;
-      self.emit('open', fd);
-      self._read();
-    })
+    currentTree[''] = route
   }
 
-  function WriteStream (path, options) {
-    if (!(this instanceof WriteStream)) return new WriteStream(path, options);
 
-    Stream.call(this);
-
-    this.path = path;
-    this.fd = null;
-    this.writable = true;
-
-    this.flags = 'w';
-    this.encoding = 'binary';
-    this.mode = 438; /*=0666*/
-    this.bytesWritten = 0;
-
-    options = options || {};
-
-    // Mixin options into this
-    var keys = Object.keys(options);
-    for (var index = 0, length = keys.length; index < length; index++) {
-      var key = keys[index];
-      this[key] = options[key];
-    }
-
-    if (this.start !== undefined) {
-      if ('number' !== typeof this.start) {
-        throw TypeError('start must be a Number');
-      }
-      if (this.start < 0) {
-        throw new Error('start must be >= zero');
-      }
-
-      this.pos = this.start;
-    }
-
-    this.busy = false;
-    this._queue = [];
-
-    if (this.fd === null) {
-      this._open = fs.open;
-      this._queue.push([this._open, this.path, this.flags, this.mode, undefined]);
-      this.flush();
-    }
-  }
-}
-
-},{"stream":undefined}],9:[function(require,module,exports){
-var fs = require('./fs.js')
-var constants = require('constants')
-
-var origCwd = process.cwd
-var cwd = null
-
-var platform = process.env.GRACEFUL_FS_PLATFORM || process.platform
-
-process.cwd = function() {
-  if (!cwd)
-    cwd = origCwd.call(process)
-  return cwd
-}
-try {
-  process.cwd()
-} catch (er) {}
-
-var chdir = process.chdir
-process.chdir = function(d) {
-  cwd = null
-  chdir.call(process, d)
-}
-
-module.exports = patch
-
-function patch (fs) {
-  // (re-)implement some things that are known busted or missing.
-
-  // lchmod, broken prior to 0.6.2
-  // back-port the fix here.
-  if (constants.hasOwnProperty('O_SYMLINK') &&
-      process.version.match(/^v0\.6\.[0-2]|^v0\.5\./)) {
-    patchLchmod(fs)
-  }
-
-  // lutimes implementation, or no-op
-  if (!fs.lutimes) {
-    patchLutimes(fs)
-  }
-
-  // https://github.com/isaacs/node-graceful-fs/issues/4
-  // Chown should not fail on einval or eperm if non-root.
-  // It should not fail on enosys ever, as this just indicates
-  // that a fs doesn't support the intended operation.
-
-  fs.chown = chownFix(fs.chown)
-  fs.fchown = chownFix(fs.fchown)
-  fs.lchown = chownFix(fs.lchown)
-
-  fs.chmod = chmodFix(fs.chmod)
-  fs.fchmod = chmodFix(fs.fchmod)
-  fs.lchmod = chmodFix(fs.lchmod)
-
-  fs.chownSync = chownFixSync(fs.chownSync)
-  fs.fchownSync = chownFixSync(fs.fchownSync)
-  fs.lchownSync = chownFixSync(fs.lchownSync)
-
-  fs.chmodSync = chmodFixSync(fs.chmodSync)
-  fs.fchmodSync = chmodFixSync(fs.fchmodSync)
-  fs.lchmodSync = chmodFixSync(fs.lchmodSync)
-
-  fs.stat = statFix(fs.stat)
-  fs.fstat = statFix(fs.fstat)
-  fs.lstat = statFix(fs.lstat)
-
-  fs.statSync = statFixSync(fs.statSync)
-  fs.fstatSync = statFixSync(fs.fstatSync)
-  fs.lstatSync = statFixSync(fs.lstatSync)
-
-  // if lchmod/lchown do not exist, then make them no-ops
-  if (!fs.lchmod) {
-    fs.lchmod = function (path, mode, cb) {
-      if (cb) process.nextTick(cb)
-    }
-    fs.lchmodSync = function () {}
-  }
-  if (!fs.lchown) {
-    fs.lchown = function (path, uid, gid, cb) {
-      if (cb) process.nextTick(cb)
-    }
-    fs.lchownSync = function () {}
-  }
-
-  // on Windows, A/V software can lock the directory, causing this
-  // to fail with an EACCES or EPERM if the directory contains newly
-  // created files.  Try again on failure, for up to 60 seconds.
-
-  // Set the timeout this long because some Windows Anti-Virus, such as Parity
-  // bit9, may lock files for up to a minute, causing npm package install
-  // failures. Also, take care to yield the scheduler. Windows scheduling gives
-  // CPU to a busy looping process, which can cause the program causing the lock
-  // contention to be starved of CPU by node, so the contention doesn't resolve.
-  if (platform === "win32") {
-    fs.rename = (function (fs$rename) { return function (from, to, cb) {
-      var start = Date.now()
-      var backoff = 0;
-      fs$rename(from, to, function CB (er) {
-        if (er
-            && (er.code === "EACCES" || er.code === "EPERM")
-            && Date.now() - start < 60000) {
-          setTimeout(function() {
-            fs.stat(to, function (stater, st) {
-              if (stater && stater.code === "ENOENT")
-                fs$rename(from, to, CB);
-              else
-                cb(er)
-            })
-          }, backoff)
-          if (backoff < 100)
-            backoff += 10;
-          return;
-        }
-        if (cb) cb(er)
-      })
-    }})(fs.rename)
-  }
-
-  // if read() returns EAGAIN, then just try it again.
-  fs.read = (function (fs$read) { return function (fd, buffer, offset, length, position, callback_) {
-    var callback
-    if (callback_ && typeof callback_ === 'function') {
-      var eagCounter = 0
-      callback = function (er, _, __) {
-        if (er && er.code === 'EAGAIN' && eagCounter < 10) {
-          eagCounter ++
-          return fs$read.call(fs, fd, buffer, offset, length, position, callback)
-        }
-        callback_.apply(this, arguments)
-      }
-    }
-    return fs$read.call(fs, fd, buffer, offset, length, position, callback)
-  }})(fs.read)
-
-  fs.readSync = (function (fs$readSync) { return function (fd, buffer, offset, length, position) {
-    var eagCounter = 0
-    while (true) {
-      try {
-        return fs$readSync.call(fs, fd, buffer, offset, length, position)
-      } catch (er) {
-        if (er.code === 'EAGAIN' && eagCounter < 10) {
-          eagCounter ++
-          continue
-        }
-        throw er
-      }
-    }
-  }})(fs.readSync)
-}
-
-function patchLchmod (fs) {
-  fs.lchmod = function (path, mode, callback) {
-    fs.open( path
-           , constants.O_WRONLY | constants.O_SYMLINK
-           , mode
-           , function (err, fd) {
-      if (err) {
-        if (callback) callback(err)
-        return
-      }
-      // prefer to return the chmod error, if one occurs,
-      // but still try to close, and report closing errors if they occur.
-      fs.fchmod(fd, mode, function (err) {
-        fs.close(fd, function(err2) {
-          if (callback) callback(err || err2)
-        })
-      })
-    })
-  }
-
-  fs.lchmodSync = function (path, mode) {
-    var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK, mode)
-
-    // prefer to return the chmod error, if one occurs,
-    // but still try to close, and report closing errors if they occur.
-    var threw = true
-    var ret
-    try {
-      ret = fs.fchmodSync(fd, mode)
-      threw = false
-    } finally {
-      if (threw) {
-        try {
-          fs.closeSync(fd)
-        } catch (er) {}
-      } else {
-        fs.closeSync(fd)
-      }
-    }
-    return ret
-  }
-}
-
-function patchLutimes (fs) {
-  if (constants.hasOwnProperty("O_SYMLINK")) {
-    fs.lutimes = function (path, at, mt, cb) {
-      fs.open(path, constants.O_SYMLINK, function (er, fd) {
-        if (er) {
-          if (cb) cb(er)
-          return
-        }
-        fs.futimes(fd, at, mt, function (er) {
-          fs.close(fd, function (er2) {
-            if (cb) cb(er || er2)
-          })
-        })
-      })
-    }
-
-    fs.lutimesSync = function (path, at, mt) {
-      var fd = fs.openSync(path, constants.O_SYMLINK)
-      var ret
-      var threw = true
-      try {
-        ret = fs.futimesSync(fd, at, mt)
-        threw = false
-      } finally {
-        if (threw) {
-          try {
-            fs.closeSync(fd)
-          } catch (er) {}
-        } else {
-          fs.closeSync(fd)
-        }
-      }
-      return ret
-    }
-
-  } else {
-    fs.lutimes = function (_a, _b, _c, cb) { if (cb) process.nextTick(cb) }
-    fs.lutimesSync = function () {}
-  }
-}
-
-function chmodFix (orig) {
-  if (!orig) return orig
-  return function (target, mode, cb) {
-    return orig.call(fs, target, mode, function (er) {
-      if (chownErOk(er)) er = null
-      if (cb) cb.apply(this, arguments)
-    })
-  }
-}
-
-function chmodFixSync (orig) {
-  if (!orig) return orig
-  return function (target, mode) {
-    try {
-      return orig.call(fs, target, mode)
-    } catch (er) {
-      if (!chownErOk(er)) throw er
-    }
-  }
-}
-
-
-function chownFix (orig) {
-  if (!orig) return orig
-  return function (target, uid, gid, cb) {
-    return orig.call(fs, target, uid, gid, function (er) {
-      if (chownErOk(er)) er = null
-      if (cb) cb.apply(this, arguments)
-    })
-  }
-}
-
-function chownFixSync (orig) {
-  if (!orig) return orig
-  return function (target, uid, gid) {
-    try {
-      return orig.call(fs, target, uid, gid)
-    } catch (er) {
-      if (!chownErOk(er)) throw er
-    }
-  }
-}
-
-
-function statFix (orig) {
-  if (!orig) return orig
-  // Older versions of Node erroneously returned signed integers for
-  // uid + gid.
-  return function (target, cb) {
-    return orig.call(fs, target, function (er, stats) {
-      if (!stats) return cb.apply(this, arguments)
-      if (stats.uid < 0) stats.uid += 0x100000000
-      if (stats.gid < 0) stats.gid += 0x100000000
-      if (cb) cb.apply(this, arguments)
-    })
-  }
-}
-
-function statFixSync (orig) {
-  if (!orig) return orig
-  // Older versions of Node erroneously returned signed integers for
-  // uid + gid.
-  return function (target) {
-    var stats = orig.call(fs, target)
-    if (stats.uid < 0) stats.uid += 0x100000000
-    if (stats.gid < 0) stats.gid += 0x100000000
-    return stats;
-  }
-}
-
-// ENOSYS means that the fs doesn't support the op. Just ignore
-// that, because it doesn't matter.
-//
-// if there's no getuid, or if getuid() is something other
-// than 0, and the error is EINVAL or EPERM, then just ignore
-// it.
-//
-// This specific case is a silent failure in cp, install, tar,
-// and most other unix tools that manage permissions.
-//
-// When running as root, or if other types of errors are
-// encountered, then it's strict.
-function chownErOk (er) {
-  if (!er)
-    return true
-
-  if (er.code === "ENOSYS")
-    return true
-
-  var nonroot = !process.getuid || process.getuid() !== 0
-  if (nonroot) {
-    if (er.code === "EINVAL" || er.code === "EPERM")
-      return true
-  }
-
-  return false
-}
-
-},{"./fs.js":6,"constants":undefined}],10:[function(require,module,exports){
-'use strict';
-
-module.exports = function isArrayish(obj) {
-	if (!obj) {
-		return false;
-	}
-
-	return obj instanceof Array || Array.isArray(obj) ||
-		(obj.length >= 0 && obj.splice instanceof Function);
-};
-
-},{}],11:[function(require,module,exports){
-'use strict';
-const path = require('path');
-const fs = require('graceful-fs');
-const stripBom = require('strip-bom');
-const parseJson = require('parse-json');
-const pify = require('pify');
-
-const parse = (data, fp) => parseJson(stripBom(data), path.relative('.', fp));
-
-module.exports = fp => pify(fs.readFile)(fp, 'utf8').then(data => parse(data, fp));
-module.exports.sync = fp => parse(fs.readFileSync(fp, 'utf8'), fp);
-
-},{"graceful-fs":7,"parse-json":14,"path":undefined,"pify":12,"strip-bom":13}],12:[function(require,module,exports){
-'use strict';
-
-var processFn = function (fn, P, opts) {
-	return function () {
-		var that = this;
-		var args = new Array(arguments.length);
-
-		for (var i = 0; i < arguments.length; i++) {
-			args[i] = arguments[i];
-		}
-
-		return new P(function (resolve, reject) {
-			args.push(function (err, result) {
-				if (err) {
-					reject(err);
-				} else if (opts.multiArgs) {
-					var results = new Array(arguments.length - 1);
-
-					for (var i = 1; i < arguments.length; i++) {
-						results[i - 1] = arguments[i];
-					}
-
-					resolve(results);
-				} else {
-					resolve(result);
-				}
-			});
-
-			fn.apply(that, args);
-		});
-	};
-};
-
-var pify = module.exports = function (obj, P, opts) {
-	if (typeof P !== 'function') {
-		opts = P;
-		P = Promise;
-	}
-
-	opts = opts || {};
-	opts.exclude = opts.exclude || [/.+Sync$/];
-
-	var filter = function (key) {
-		var match = function (pattern) {
-			return typeof pattern === 'string' ? key === pattern : pattern.test(key);
-		};
-
-		return opts.include ? opts.include.some(match) : !opts.exclude.some(match);
-	};
-
-	var ret = typeof obj === 'function' ? function () {
-		if (opts.excludeMain) {
-			return obj.apply(this, arguments);
-		}
-
-		return processFn(obj, P, opts).apply(this, arguments);
-	} : {};
-
-	return Object.keys(obj).reduce(function (ret, key) {
-		var x = obj[key];
-
-		ret[key] = typeof x === 'function' && filter(key) ? processFn(x, P, opts) : x;
-
-		return ret;
-	}, ret);
-};
-
-pify.all = pify;
-
-},{}],13:[function(require,module,exports){
-'use strict';
-module.exports = x => {
-	if (typeof x !== 'string') {
-		throw new TypeError('Expected a string, got ' + typeof x);
-	}
-
-	// Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
-	// conversion translates it to FEFF (UTF-16 BOM)
-	if (x.charCodeAt(0) === 0xFEFF) {
-		return x.slice(1);
-	}
-
-	return x;
-};
-
-},{}],14:[function(require,module,exports){
-'use strict';
-var errorEx = require('error-ex');
-var fallback = require('./vendor/parse');
-
-var JSONError = errorEx('JSONError', {
-	fileName: errorEx.append('in %s')
-});
-
-module.exports = function (x, reviver, filename) {
-	if (typeof reviver === 'string') {
-		filename = reviver;
-		reviver = null;
-	}
-
-	try {
-		try {
-			return JSON.parse(x, reviver);
-		} catch (err) {
-			fallback.parse(x, {
-				mode: 'json',
-				reviver: reviver
-			});
-
-			throw err;
-		}
-	} catch (err) {
-		var jsonErr = new JSONError(err);
-
-		if (filename) {
-			jsonErr.fileName = filename;
-		}
-
-		throw jsonErr;
-	}
-};
-
-},{"./vendor/parse":15,"error-ex":5}],15:[function(require,module,exports){
-/*
- * Author: Alex Kocharin <alex@kocharin.ru>
- * GIT: https://github.com/rlidwka/jju
- * License: WTFPL, grab your copy here: http://www.wtfpl.net/txt/copying/
- */
-
-// RTFM: http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf
-
-var Uni = require('./unicode')
-
-function isHexDigit(x) {
-  return (x >= '0' && x <= '9')
-      || (x >= 'A' && x <= 'F')
-      || (x >= 'a' && x <= 'f')
-}
-
-function isOctDigit(x) {
-  return x >= '0' && x <= '7'
-}
-
-function isDecDigit(x) {
-  return x >= '0' && x <= '9'
-}
-
-var unescapeMap = {
-  '\'': '\'',
-  '"' : '"',
-  '\\': '\\',
-  'b' : '\b',
-  'f' : '\f',
-  'n' : '\n',
-  'r' : '\r',
-  't' : '\t',
-  'v' : '\v',
-  '/' : '/',
-}
-
-function formatError(input, msg, position, lineno, column, json5) {
-  var result = msg + ' at ' + (lineno + 1) + ':' + (column + 1)
-    , tmppos = position - column - 1
-    , srcline = ''
-    , underline = ''
-
-  var isLineTerminator = json5 ? Uni.isLineTerminator : Uni.isLineTerminatorJSON
-
-  // output no more than 70 characters before the wrong ones
-  if (tmppos < position - 70) {
-    tmppos = position - 70
-  }
-
-  while (1) {
-    var chr = input[++tmppos]
-
-    if (isLineTerminator(chr) || tmppos === input.length) {
-      if (position >= tmppos) {
-        // ending line error, so show it after the last char
-        underline += '^'
-      }
-      break
-    }
-    srcline += chr
-
-    if (position === tmppos) {
-      underline += '^'
-    } else if (position > tmppos) {
-      underline += input[tmppos] === '\t' ? '\t' : ' '
-    }
-
-    // output no more than 78 characters on the string
-    if (srcline.length > 78) break
-  }
-
-  return result + '\n' + srcline + '\n' + underline
-}
-
-function parse(input, options) {
-  // parse as a standard JSON mode
-  var json5 = !(options.mode === 'json' || options.legacy)
-  var isLineTerminator = json5 ? Uni.isLineTerminator : Uni.isLineTerminatorJSON
-  var isWhiteSpace = json5 ? Uni.isWhiteSpace : Uni.isWhiteSpaceJSON
-
-  var length = input.length
-    , lineno = 0
-    , linestart = 0
-    , position = 0
-    , stack = []
-
-  var tokenStart = function() {}
-  var tokenEnd = function(v) {return v}
-
-  /* tokenize({
-       raw: '...',
-       type: 'whitespace'|'comment'|'key'|'literal'|'separator'|'newline',
-       value: 'number'|'string'|'whatever',
-       path: [...],
-     })
-  */
-  if (options._tokenize) {
-    ;(function() {
-      var start = null
-      tokenStart = function() {
-        if (start !== null) throw Error('internal error, token overlap')
-        start = position
-      }
-
-      tokenEnd = function(v, type) {
-        if (start != position) {
-          var hash = {
-            raw: input.substr(start, position-start),
-            type: type,
-            stack: stack.slice(0),
-          }
-          if (v !== undefined) hash.value = v
-          options._tokenize.call(null, hash)
-        }
-        start = null
-        return v
-      }
-    })()
-  }
-
-  function fail(msg) {
-    var column = position - linestart
-
-    if (!msg) {
-      if (position < length) {
-        var token = '\'' +
-          JSON
-            .stringify(input[position])
-            .replace(/^"|"$/g, '')
-            .replace(/'/g, "\\'")
-            .replace(/\\"/g, '"')
-          + '\''
-
-        if (!msg) msg = 'Unexpected token ' + token
-      } else {
-        if (!msg) msg = 'Unexpected end of input'
+  function createRouter(routes, aliases) {
+    var parts, name, route;
+    var routesParams = {};
+    var lookupTree = new LookupTree;
+
+    // By default, there are no aliases
+    aliases = aliases || {};
+
+    // Copy routes into lookup tree
+    for (name in routes) {
+      if (routes.hasOwnProperty(name)) {
+        route = routes[name]
+
+        assert(
+          typeof route == 'string',
+          "Route '%s' must be a string", name
+        )
+        assert(
+          name.indexOf('.') == -1,
+          "Route names must not contain the '.' character", name
+        )
+
+        parts = routeParts(route)
+
+        routesParams[name] = parts
+          .map(function(part, i) { return part[0] == ':' && [part.substr(1), i] })
+          .filter(function(x) { return x })
+
+        lookupTree.add(parts, name)
       }
     }
 
-    var error = SyntaxError(formatError(input, msg, position, lineno, column, json5))
-    error.row = lineno + 1
-    error.column = column + 1
-    throw error
-  }
+    // Copy aliases into lookup tree
+    for (route in aliases) {
+      if (aliases.hasOwnProperty(route)) {
+        name = aliases[route]
 
-  function newline(chr) {
-    // account for <cr><lf>
-    if (chr === '\r' && input[position] === '\n') position++
-    linestart = position
-    lineno++
-  }
+        assert(
+          routes[name],
+          "Alias from '%s' to non-existent route '%s'.", route, name
+        )
 
-  function parseGeneric() {
-    var result
-
-    while (position < length) {
-      tokenStart()
-      var chr = input[position++]
-
-      if (chr === '"' || (chr === '\'' && json5)) {
-        return tokenEnd(parseString(chr), 'literal')
-
-      } else if (chr === '{') {
-        tokenEnd(undefined, 'separator')
-        return parseObject()
-
-      } else if (chr === '[') {
-        tokenEnd(undefined, 'separator')
-        return parseArray()
-
-      } else if (chr === '-'
-             ||  chr === '.'
-             ||  isDecDigit(chr)
-                 //           + number       Infinity          NaN
-             ||  (json5 && (chr === '+' || chr === 'I' || chr === 'N'))
-      ) {
-        return tokenEnd(parseNumber(), 'literal')
-
-      } else if (chr === 'n') {
-        parseKeyword('null')
-        return tokenEnd(null, 'literal')
-
-      } else if (chr === 't') {
-        parseKeyword('true')
-        return tokenEnd(true, 'literal')
-
-      } else if (chr === 'f') {
-        parseKeyword('false')
-        return tokenEnd(false, 'literal')
-
-      } else {
-        position--
-        return tokenEnd(undefined)
+        lookupTree.add(routeParts(route), name);
       }
     }
-  }
 
-  function parseKey() {
-    var result
 
-    while (position < length) {
-      tokenStart()
-      var chr = input[position++]
+    return {
+      lookup: function(uri, method) {
+        method = method ? method.toUpperCase() : 'GET'
 
-      if (chr === '"' || (chr === '\'' && json5)) {
-        return tokenEnd(parseString(chr), 'key')
+        var i, x
 
-      } else if (chr === '{') {
-        tokenEnd(undefined, 'separator')
-        return parseObject()
+        var split = uri
+          // Strip leading and trailing '/' (at end or before query string)
+          .replace(/^\/|\/($|\?)/g, '')
+          // Strip fragment identifiers
+          .replace(/#.*$/, '')
+          .split('?', 2)
 
-      } else if (chr === '[') {
-        tokenEnd(undefined, 'separator')
-        return parseArray()
+        var parts = pathParts(split[0]).map(decodeURIComponent).concat(method)
+        var name = lookupTree.find(parts)
+        var options = {}
+        var params, queryParts
 
-      } else if (chr === '.'
-             ||  isDecDigit(chr)
-      ) {
-        return tokenEnd(parseNumber(true), 'key')
-
-      } else if (json5
-             &&  Uni.isIdentifierStart(chr) || (chr === '\\' && input[position] === 'u')) {
-        // unicode char or a unicode sequence
-        var rollback = position - 1
-        var result = parseIdentifier()
-
-        if (result === undefined) {
-          position = rollback
-          return tokenEnd(undefined)
-        } else {
-          return tokenEnd(result, 'key')
+        params = routesParams[name] || []
+        queryParts = split[1] ? split[1].split('&') : []
+      
+        for (i = 0; i != queryParts.length; i++) {
+          x = queryParts[i].split('=')
+          options[x[0]] = decodeURIComponent(x[1])
         }
 
-      } else {
-        position--
-        return tokenEnd(undefined)
-      }
-    }
-  }
-
-  function skipWhiteSpace() {
-    tokenStart()
-    while (position < length) {
-      var chr = input[position++]
-
-      if (isLineTerminator(chr)) {
-        position--
-        tokenEnd(undefined, 'whitespace')
-        tokenStart()
-        position++
-        newline(chr)
-        tokenEnd(undefined, 'newline')
-        tokenStart()
-
-      } else if (isWhiteSpace(chr)) {
-        // nothing
-
-      } else if (chr === '/'
-             && json5
-             && (input[position] === '/' || input[position] === '*')
-      ) {
-        position--
-        tokenEnd(undefined, 'whitespace')
-        tokenStart()
-        position++
-        skipComment(input[position++] === '*')
-        tokenEnd(undefined, 'comment')
-        tokenStart()
-
-      } else {
-        position--
-        break
-      }
-    }
-    return tokenEnd(undefined, 'whitespace')
-  }
-
-  function skipComment(multi) {
-    while (position < length) {
-      var chr = input[position++]
-
-      if (isLineTerminator(chr)) {
-        // LineTerminator is an end of singleline comment
-        if (!multi) {
-          // let parent function deal with newline
-          position--
-          return
+        // Named parameters overwrite query parameters
+        for (i = 0; i != params.length; i++) {
+          x = params[i]
+          options[x[0]] = parts[x[1]]
         }
 
-        newline(chr)
+        return {name: name, options: options}
+      },
 
-      } else if (chr === '*' && multi) {
-        // end of multiline comment
-        if (input[position] === '/') {
-          position++
-          return
-        }
 
-      } else {
-        // nothing
-      }
-    }
+      generate: function(name, options) {
+        options = options || {}
 
-    if (multi) {
-      fail('Unclosed multiline comment')
-    }
-  }
+        var params = routesParams[name] || []
+        var paramNames = params.map(function(x) { return x[0]; })
+        var route = routes[name]
+        var query = []
+        var inject = []
+        var key
 
-  function parseKeyword(keyword) {
-    // keyword[0] is not checked because it should've checked earlier
-    var _pos = position
-    var len = keyword.length
-    for (var i=1; i<len; i++) {
-      if (position >= length || keyword[i] != input[position]) {
-        position = _pos-1
-        fail()
-      }
-      position++
-    }
-  }
+        assert(route, "No route with name `%s` exists", name)
 
-  function parseObject() {
-    var result = options.null_prototype ? Object.create(null) : {}
-      , empty_object = {}
-      , is_non_empty = false
+        var path = route.split(' ')[1]
 
-    while (position < length) {
-      skipWhiteSpace()
-      var item1 = parseKey()
-      skipWhiteSpace()
-      tokenStart()
-      var chr = input[position++]
-      tokenEnd(undefined, 'separator')
+        for (key in options) {
+          if (options.hasOwnProperty(key)) {
+            if (paramNames.indexOf(key) === -1) {
+              assert(
+                /^[a-zA-Z0-9-_]+$/.test(key),
+                "Non-route parameters must use only the following characters: A-Z, a-z, 0-9, -, _"
+              )
 
-      if (chr === '}' && item1 === undefined) {
-        if (!json5 && is_non_empty) {
-          position--
-          fail('Trailing comma in object')
-        }
-        return result
-
-      } else if (chr === ':' && item1 !== undefined) {
-        skipWhiteSpace()
-        stack.push(item1)
-        var item2 = parseGeneric()
-        stack.pop()
-
-        if (item2 === undefined) fail('No value found for key ' + item1)
-        if (typeof(item1) !== 'string') {
-          if (!json5 || typeof(item1) !== 'number') {
-            fail('Wrong key type: ' + item1)
+              query.push(key+'='+encodeURIComponent(options[key]))
+            }
+            else {
+              inject.push(key)
+            }
           }
         }
 
-        if ((item1 in empty_object || empty_object[item1] != null) && options.reserved_keys !== 'replace') {
-          if (options.reserved_keys === 'throw') {
-            fail('Reserved key: ' + item1)
-          } else {
-            // silently ignore it
-          }
-        } else {
-          if (typeof(options.reviver) === 'function') {
-            item2 = options.reviver.call(null, item1, item2)
-          }
+        assert(
+          inject.sort().join() == paramNames.slice(0).sort().join(),
+          "You must specify options for all route params when using `uri`."
+        )
 
-          if (item2 !== undefined) {
-            is_non_empty = true
-            Object.defineProperty(result, item1, {
-              value: item2,
-              enumerable: true,
-              configurable: true,
-              writable: true,
-            })
-          }
+        var uri =
+          paramNames.reduce(function pathReducer(injected, key) {
+            return injected.replace(':'+key, encodeURIComponent(options[key]))
+          }, path)
+
+        if (query.length) {
+          uri += '?' + query.join('&')
         }
 
-        skipWhiteSpace()
-
-        tokenStart()
-        var chr = input[position++]
-        tokenEnd(undefined, 'separator')
-
-        if (chr === ',') {
-          continue
-
-        } else if (chr === '}') {
-          return result
-
-        } else {
-          fail()
-        }
-
-      } else {
-        position--
-        fail()
+        return uri
       }
-    }
-
-    fail()
+    };
   }
 
-  function parseArray() {
-    var result = []
 
-    while (position < length) {
-      skipWhiteSpace()
-      stack.push(result.length)
-      var item = parseGeneric()
-      stack.pop()
-      skipWhiteSpace()
-      tokenStart()
-      var chr = input[position++]
-      tokenEnd(undefined, 'separator')
-
-      if (item !== undefined) {
-        if (typeof(options.reviver) === 'function') {
-          item = options.reviver.call(null, String(result.length), item)
-        }
-        if (item === undefined) {
-          result.length++
-          item = true // hack for check below, not included into result
-        } else {
-          result.push(item)
-        }
-      }
-
-      if (chr === ',') {
-        if (item === undefined) {
-          fail('Elisions are not supported')
-        }
-
-      } else if (chr === ']') {
-        if (!json5 && item === undefined && result.length) {
-          position--
-          fail('Trailing comma in array')
-        }
-        return result
-
-      } else {
-        position--
-        fail()
-      }
-    }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = createRouter
   }
-
-  function parseNumber() {
-    // rewind because we don't know first char
-    position--
-
-    var start = position
-      , chr = input[position++]
-      , t
-
-    var to_num = function(is_octal) {
-      var str = input.substr(start, position - start)
-
-      if (is_octal) {
-        var result = parseInt(str.replace(/^0o?/, ''), 8)
-      } else {
-        var result = Number(str)
-      }
-
-      if (Number.isNaN(result)) {
-        position--
-        fail('Bad numeric literal - "' + input.substr(start, position - start + 1) + '"')
-      } else if (!json5 && !str.match(/^-?(0|[1-9][0-9]*)(\.[0-9]+)?(e[+-]?[0-9]+)?$/i)) {
-        // additional restrictions imposed by json
-        position--
-        fail('Non-json numeric literal - "' + input.substr(start, position - start + 1) + '"')
-      } else {
-        return result
-      }
-    }
-
-    // ex: -5982475.249875e+29384
-    //     ^ skipping this
-    if (chr === '-' || (chr === '+' && json5)) chr = input[position++]
-
-    if (chr === 'N' && json5) {
-      parseKeyword('NaN')
-      return NaN
-    }
-
-    if (chr === 'I' && json5) {
-      parseKeyword('Infinity')
-
-      // returning +inf or -inf
-      return to_num()
-    }
-
-    if (chr >= '1' && chr <= '9') {
-      // ex: -5982475.249875e+29384
-      //        ^^^ skipping these
-      while (position < length && isDecDigit(input[position])) position++
-      chr = input[position++]
-    }
-
-    // special case for leading zero: 0.123456
-    if (chr === '0') {
-      chr = input[position++]
-
-      //             new syntax, "0o777"           old syntax, "0777"
-      var is_octal = chr === 'o' || chr === 'O' || isOctDigit(chr)
-      var is_hex = chr === 'x' || chr === 'X'
-
-      if (json5 && (is_octal || is_hex)) {
-        while (position < length
-           &&  (is_hex ? isHexDigit : isOctDigit)( input[position] )
-        ) position++
-
-        var sign = 1
-        if (input[start] === '-') {
-          sign = -1
-          start++
-        } else if (input[start] === '+') {
-          start++
-        }
-
-        return sign * to_num(is_octal)
-      }
-    }
-
-    if (chr === '.') {
-      // ex: -5982475.249875e+29384
-      //                ^^^ skipping these
-      while (position < length && isDecDigit(input[position])) position++
-      chr = input[position++]
-    }
-
-    if (chr === 'e' || chr === 'E') {
-      chr = input[position++]
-      if (chr === '-' || chr === '+') position++
-      // ex: -5982475.249875e+29384
-      //                       ^^^ skipping these
-      while (position < length && isDecDigit(input[position])) position++
-      chr = input[position++]
-    }
-
-    // we have char in the buffer, so count for it
-    position--
-    return to_num()
+  else {
+    root.unirouter = createRouter
   }
+})(this);
 
-  function parseIdentifier() {
-    // rewind because we don't know first char
-    position--
-
-    var result = ''
-
-    while (position < length) {
-      var chr = input[position++]
-
-      if (chr === '\\'
-      &&  input[position] === 'u'
-      &&  isHexDigit(input[position+1])
-      &&  isHexDigit(input[position+2])
-      &&  isHexDigit(input[position+3])
-      &&  isHexDigit(input[position+4])
-      ) {
-        // UnicodeEscapeSequence
-        chr = String.fromCharCode(parseInt(input.substr(position+1, 4), 16))
-        position += 5
-      }
-
-      if (result.length) {
-        // identifier started
-        if (Uni.isIdentifierPart(chr)) {
-          result += chr
-        } else {
-          position--
-          return result
-        }
-
-      } else {
-        if (Uni.isIdentifierStart(chr)) {
-          result += chr
-        } else {
-          return undefined
-        }
-      }
-    }
-
-    fail()
-  }
-
-  function parseString(endChar) {
-    // 7.8.4 of ES262 spec
-    var result = ''
-
-    while (position < length) {
-      var chr = input[position++]
-
-      if (chr === endChar) {
-        return result
-
-      } else if (chr === '\\') {
-        if (position >= length) fail()
-        chr = input[position++]
-
-        if (unescapeMap[chr] && (json5 || (chr != 'v' && chr != "'"))) {
-          result += unescapeMap[chr]
-
-        } else if (json5 && isLineTerminator(chr)) {
-          // line continuation
-          newline(chr)
-
-        } else if (chr === 'u' || (chr === 'x' && json5)) {
-          // unicode/character escape sequence
-          var off = chr === 'u' ? 4 : 2
-
-          // validation for \uXXXX
-          for (var i=0; i<off; i++) {
-            if (position >= length) fail()
-            if (!isHexDigit(input[position])) fail('Bad escape sequence')
-            position++
-          }
-
-          result += String.fromCharCode(parseInt(input.substr(position-off, off), 16))
-        } else if (json5 && isOctDigit(chr)) {
-          if (chr < '4' && isOctDigit(input[position]) && isOctDigit(input[position+1])) {
-            // three-digit octal
-            var digits = 3
-          } else if (isOctDigit(input[position])) {
-            // two-digit octal
-            var digits = 2
-          } else {
-            var digits = 1
-          }
-          position += digits - 1
-          result += String.fromCharCode(parseInt(input.substr(position-digits, digits), 8))
-          /*if (!isOctDigit(input[position])) {
-            // \0 is allowed still
-            result += '\0'
-          } else {
-            fail('Octal literals are not supported')
-          }*/
-
-        } else if (json5) {
-          // \X -> x
-          result += chr
-
-        } else {
-          position--
-          fail()
-        }
-
-      } else if (isLineTerminator(chr)) {
-        fail()
-
-      } else {
-        if (!json5 && chr.charCodeAt(0) < 32) {
-          position--
-          fail('Unexpected control character')
-        }
-
-        // SourceCharacter but not one of " or \ or LineTerminator
-        result += chr
-      }
-    }
-
-    fail()
-  }
-
-  skipWhiteSpace()
-  var return_value = parseGeneric()
-  if (return_value !== undefined || position < length) {
-    skipWhiteSpace()
-
-    if (position >= length) {
-      if (typeof(options.reviver) === 'function') {
-        return_value = options.reviver.call(null, '', return_value)
-      }
-      return return_value
-    } else {
-      fail()
-    }
-
-  } else {
-    if (position) {
-      fail('No data, only a whitespace')
-    } else {
-      fail('No data, empty input')
-    }
-  }
-}
-
-/*
- * parse(text, options)
- * or
- * parse(text, reviver)
- *
- * where:
- * text - string
- * options - object
- * reviver - function
- */
-module.exports.parse = function parseJSON(input, options) {
-  // support legacy functions
-  if (typeof(options) === 'function') {
-    options = {
-      reviver: options
-    }
-  }
-
-  if (input === undefined) {
-    // parse(stringify(x)) should be equal x
-    // with JSON functions it is not 'cause of undefined
-    // so we're fixing it
-    return undefined
-  }
-
-  // JSON.parse compat
-  if (typeof(input) !== 'string') input = String(input)
-  if (options == null) options = {}
-  if (options.reserved_keys == null) options.reserved_keys = 'ignore'
-
-  if (options.reserved_keys === 'throw' || options.reserved_keys === 'ignore') {
-    if (options.null_prototype == null) {
-      options.null_prototype = true
-    }
-  }
-
-  try {
-    return parse(input, options)
-  } catch(err) {
-    // jju is a recursive parser, so JSON.parse("{{{{{{{") could blow up the stack
-    //
-    // this catch is used to skip all those internal calls
-    if (err instanceof SyntaxError && err.row != null && err.column != null) {
-      var old_err = err
-      err = SyntaxError(old_err.message)
-      err.column = old_err.column
-      err.row = old_err.row
-    }
-    throw err
-  }
-}
-
-module.exports.tokenize = function tokenizeJSON(input, options) {
-  if (options == null) options = {}
-
-  options._tokenize = function(smth) {
-    if (options._addstack) smth.stack.unshift.apply(smth.stack, options._addstack)
-    tokens.push(smth)
-  }
-
-  var tokens = []
-  tokens.data = module.exports.parse(input, options)
-  return tokens
-}
-
-
-},{"./unicode":16}],16:[function(require,module,exports){
-
-// This is autogenerated with esprima tools, see:
-// https://github.com/ariya/esprima/blob/master/esprima.js
-//
-// PS: oh God, I hate Unicode
-
-// ECMAScript 5.1/Unicode v6.3.0 NonAsciiIdentifierStart:
-
-var Uni = module.exports
-
-module.exports.isWhiteSpace = function isWhiteSpace(x) {
-  // section 7.2, table 2
-  return x === '\u0020'
-      || x === '\u00A0'
-      || x === '\uFEFF' // <-- this is not a Unicode WS, only a JS one
-      || (x >= '\u0009' && x <= '\u000D') // 9 A B C D
-
-      // + whitespace characters from unicode, category Zs
-      || x === '\u1680'
-      || x === '\u180E'
-      || (x >= '\u2000' && x <= '\u200A') // 0 1 2 3 4 5 6 7 8 9 A
-      || x === '\u2028'
-      || x === '\u2029'
-      || x === '\u202F'
-      || x === '\u205F'
-      || x === '\u3000'
-}
-
-module.exports.isWhiteSpaceJSON = function isWhiteSpaceJSON(x) {
-  return x === '\u0020'
-      || x === '\u0009'
-      || x === '\u000A'
-      || x === '\u000D'
-}
-
-module.exports.isLineTerminator = function isLineTerminator(x) {
-  // ok, here is the part when JSON is wrong
-  // section 7.3, table 3
-  return x === '\u000A'
-      || x === '\u000D'
-      || x === '\u2028'
-      || x === '\u2029'
-}
-
-module.exports.isLineTerminatorJSON = function isLineTerminatorJSON(x) {
-  return x === '\u000A'
-      || x === '\u000D'
-}
-
-module.exports.isIdentifierStart = function isIdentifierStart(x) {
-  return x === '$'
-      || x === '_'
-      || (x >= 'A' && x <= 'Z')
-      || (x >= 'a' && x <= 'z')
-      || (x >= '\u0080' && Uni.NonAsciiIdentifierStart.test(x))
-}
-
-module.exports.isIdentifierPart = function isIdentifierPart(x) {
-  return x === '$'
-      || x === '_'
-      || (x >= 'A' && x <= 'Z')
-      || (x >= 'a' && x <= 'z')
-      || (x >= '0' && x <= '9') // <-- addition to Start
-      || (x >= '\u0080' && Uni.NonAsciiIdentifierPart.test(x))
-}
-
-module.exports.NonAsciiIdentifierStart = /[\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05D0-\u05EA\u05F0-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u08A0\u08A2-\u08AC\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097F\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33\u0C35-\u0C39\u0C3D\u0C58\u0C59\u0C60\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D60\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E87\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA\u0EAB\u0EAD-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F0\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191C\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19C1-\u19C7\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5\u1CF6\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u212F-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u2E2F\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309D-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FCC\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA697\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA78E\uA790-\uA793\uA7A0-\uA7AA\uA7F8-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA80-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/
-
-// ECMAScript 5.1/Unicode v6.3.0 NonAsciiIdentifierPart:
-
-module.exports.NonAsciiIdentifierPart = /[\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0300-\u0374\u0376\u0377\u037A-\u037D\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u0483-\u0487\u048A-\u0527\u0531-\u0556\u0559\u0561-\u0587\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u05D0-\u05EA\u05F0-\u05F2\u0610-\u061A\u0620-\u0669\u066E-\u06D3\u06D5-\u06DC\u06DF-\u06E8\u06EA-\u06FC\u06FF\u0710-\u074A\u074D-\u07B1\u07C0-\u07F5\u07FA\u0800-\u082D\u0840-\u085B\u08A0\u08A2-\u08AC\u08E4-\u08FE\u0900-\u0963\u0966-\u096F\u0971-\u0977\u0979-\u097F\u0981-\u0983\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BC-\u09C4\u09C7\u09C8\u09CB-\u09CE\u09D7\u09DC\u09DD\u09DF-\u09E3\u09E6-\u09F1\u0A01-\u0A03\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A59-\u0A5C\u0A5E\u0A66-\u0A75\u0A81-\u0A83\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABC-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AD0\u0AE0-\u0AE3\u0AE6-\u0AEF\u0B01-\u0B03\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3C-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B56\u0B57\u0B5C\u0B5D\u0B5F-\u0B63\u0B66-\u0B6F\u0B71\u0B82\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD0\u0BD7\u0BE6-\u0BEF\u0C01-\u0C03\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33\u0C35-\u0C39\u0C3D-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C58\u0C59\u0C60-\u0C63\u0C66-\u0C6F\u0C82\u0C83\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBC-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CDE\u0CE0-\u0CE3\u0CE6-\u0CEF\u0CF1\u0CF2\u0D02\u0D03\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D-\u0D44\u0D46-\u0D48\u0D4A-\u0D4E\u0D57\u0D60-\u0D63\u0D66-\u0D6F\u0D7A-\u0D7F\u0D82\u0D83\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DF2\u0DF3\u0E01-\u0E3A\u0E40-\u0E4E\u0E50-\u0E59\u0E81\u0E82\u0E84\u0E87\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA\u0EAB\u0EAD-\u0EB9\u0EBB-\u0EBD\u0EC0-\u0EC4\u0EC6\u0EC8-\u0ECD\u0ED0-\u0ED9\u0EDC-\u0EDF\u0F00\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E-\u0F47\u0F49-\u0F6C\u0F71-\u0F84\u0F86-\u0F97\u0F99-\u0FBC\u0FC6\u1000-\u1049\u1050-\u109D\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u135D-\u135F\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F0\u1700-\u170C\u170E-\u1714\u1720-\u1734\u1740-\u1753\u1760-\u176C\u176E-\u1770\u1772\u1773\u1780-\u17D3\u17D7\u17DC\u17DD\u17E0-\u17E9\u180B-\u180D\u1810-\u1819\u1820-\u1877\u1880-\u18AA\u18B0-\u18F5\u1900-\u191C\u1920-\u192B\u1930-\u193B\u1946-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u19D0-\u19D9\u1A00-\u1A1B\u1A20-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AA7\u1B00-\u1B4B\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1BF3\u1C00-\u1C37\u1C40-\u1C49\u1C4D-\u1C7D\u1CD0-\u1CD2\u1CD4-\u1CF6\u1D00-\u1DE6\u1DFC-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u200C\u200D\u203F\u2040\u2054\u2071\u207F\u2090-\u209C\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2102\u2107\u210A-\u2113\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u212F-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D7F-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u2DE0-\u2DFF\u2E2F\u3005-\u3007\u3021-\u302F\u3031-\u3035\u3038-\u303C\u3041-\u3096\u3099\u309A\u309D-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FCC\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA62B\uA640-\uA66F\uA674-\uA67D\uA67F-\uA697\uA69F-\uA6F1\uA717-\uA71F\uA722-\uA788\uA78B-\uA78E\uA790-\uA793\uA7A0-\uA7AA\uA7F8-\uA827\uA840-\uA873\uA880-\uA8C4\uA8D0-\uA8D9\uA8E0-\uA8F7\uA8FB\uA900-\uA92D\uA930-\uA953\uA960-\uA97C\uA980-\uA9C0\uA9CF-\uA9D9\uAA00-\uAA36\uAA40-\uAA4D\uAA50-\uAA59\uAA60-\uAA76\uAA7A\uAA7B\uAA80-\uAAC2\uAADB-\uAADD\uAAE0-\uAAEF\uAAF2-\uAAF6\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABEA\uABEC\uABED\uABF0-\uABF9\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE00-\uFE0F\uFE20-\uFE26\uFE33\uFE34\uFE4D-\uFE4F\uFE70-\uFE74\uFE76-\uFEFC\uFF10-\uFF19\uFF21-\uFF3A\uFF3F\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/
-
-},{}],17:[function(require,module,exports){
+},{}],6:[function(require,module,exports){
 /**
 This module exports a "handler" function,
 that wraps a customer function.
@@ -2058,8 +465,6 @@ import type {
 */
 
 const path = require('path')
-
-const loadJsonFile = require('load-json-file')
 
 const handlers = require('../lib/handlers.js')
 const wrapper = require('../lib/wrapper.js')
@@ -2080,10 +485,11 @@ function normaliseLambdaRequest (
     body,
     headers,
     method: wrapper.normaliseMethod(event.httpMethod),
+    route: '',
     url: {
       host,
       hostname: host,
-      params: event.pathParameters || {},
+      params: {},
       pathname: event.path,
       protocol: wrapper.protocolFromHeaders(headers),
       query: event.queryStringParameters || {}
@@ -2100,20 +506,61 @@ function handler (
     statusCode: number
   }) => void */
 ) /* : Promise<void> */ {
+  const startTime = Date.now()
   const request = normaliseLambdaRequest(event)
-  const configPath = path.join(__dirname, 'bm-server.json')
   const internalHeaders = {}
   internalHeaders['Content-Type'] = 'application/json'
   const finish = (statusCode, body, customHeaders) => {
     const headers = Object.assign(internalHeaders, customHeaders)
+    const endTime = Date.now()
+    const requestTime = endTime - startTime
+    console.log('BLINKM_ANALYTICS_EVENT', JSON.stringify({ // eslint-disable-line no-console
+      request: {
+        method: request.method.toUpperCase(),
+        query: request.url.query,
+        port: 443,
+        path: request.route || request.url.pathname,
+        hostName: request.url.hostname,
+        params: request.url.params,
+        protocol: request.url.protocol
+      },
+      response: {
+        statusCode: statusCode
+      },
+      requestTime: {
+        startDateTime: new Date(startTime),
+        startTimeStamp: startTime,
+        endDateTime: new Date(endTime),
+        endTimeStamp: endTime,
+        ms: requestTime,
+        s: requestTime / 1000
+      }
+    }, null, 2))
     cb(null, {
       body: JSON.stringify(body, null, 2),
       headers: wrapper.keysToLowerCase(headers),
       statusCode: statusCode
     })
   }
-  return loadJsonFile(configPath, 'utf8')
+
+  return Promise.resolve()
+    // $FlowFixMe requiring file without string literal to accomodate for __dirname
+    .then(() => require(path.join(__dirname, 'bm-server.json')))
     .then((config) => {
+      // Get handler module based on route
+      let routeConfig
+      try {
+        routeConfig = handlers.findRouteConfig(event.path, config.routes)
+        request.url.params = routeConfig.params || {}
+        request.route = routeConfig.route
+      } catch (error) {
+        return finish(404, {
+          error: 'Not Found',
+          message: error.message,
+          statusCode: 404
+        })
+      }
+
       // Check for browser requests and apply CORS if required
       if (request.headers.origin) {
         if (!config.cors) {
@@ -2146,12 +593,6 @@ function handler (
         // For OPTIONS requests, we can just finish
         // as we have created our own implementation of CORS
         return finish(200)
-      }
-
-      // Get handler module based on route
-      const routeConfig = config.routes.find((routeConfig) => routeConfig.route === event.resource)
-      if (!routeConfig) {
-        return Promise.reject(new Error(`Could not find route configuration for route: ${event.resource}`))
       }
 
       // Change current working directory to the project
@@ -2202,5 +643,5 @@ module.exports = {
   normaliseLambdaRequest
 }
 
-},{"../lib/handlers.js":2,"../lib/wrapper.js":4,"load-json-file":11,"path":undefined}]},{},[17])(17)
+},{"../lib/handlers.js":2,"../lib/wrapper.js":4,"path":undefined}]},{},[6])(6)
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# blinkmobile / server-cli
+
+## Documentation
+
+1.  [Routes](./routes.md)
+
+1.  [Handler Functions](./handlers.md)
+
+1.  [CORS Configuration](./CORS.md)
+
+1.  [Viewing Server Logs](./logs.md)
+
+## More Information...
+
+-   [Execution Environment](./environment.md)
+
+-   [Limits & Known Issues](./limits-and-known-issues.md)
+
+-   [Root Route](./roo-route.md)
+
+-   [Suggestions](./suggestions.md)

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -99,6 +99,7 @@ curl "http://localhost:3000/request?key=123"
     "accept": "*/*"
   },
   "method": "get",
+  "route": "/request/{id}",
   "url": {
     "protocol": "http:",
     "host": "localhost:3000",
@@ -106,8 +107,10 @@ curl "http://localhost:3000/request?key=123"
     "query": {
       "key": "123"
     },
-    "pathname": "/request",
-    "params": {}
+    "pathname": "/request/abc",
+    "params": {
+      "id": "abc"
+    }
   }
 }
 ```
@@ -119,15 +122,15 @@ curl "http://localhost:3000/request?key=123"
 -   See [response example](../examples/directory/response/index.js) for useage
 
 ```js
-interface response = {
+interface Response = {
   headers: {
     [id:string]: string
   },
   payload: any,
   statusCode: number,
-  setHeader: (key: string, value: string) => this
-  setPayload: (payload: any) => this
-  setStatusCode: (code: number) => this
+  setHeader: (key: string, value: string) => Response,
+  setPayload: (payload: any) => Response,
+  setStatusCode: (code: number) => Response
 }
 ```
 

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -11,10 +11,10 @@ Your Handlers can contain logging statements. The following Node.js statements g
 
 ### Server Logs
 
-Once your project has been deployed you can view the server logs for a specific route using the following command:
+Once your project has been deployed you can view the server logs using the following command:
 
 ```bash
-bm server logs /helloworld
+bm server logs
 ```
 
 **Note:** There's a small lag between invoking the function and actually having the log event registered. So it takes a few seconds for the logs to show up right after invoking the function.
@@ -53,19 +53,19 @@ bm server logs /helloworld
 -   View the logs that happened in the past 5 hours:
 
     ```bash
-    bm server logs /helloworld --start-time 5h
+    bm server logs --start-time 5h
     ```
 
 -   View the logs that happened starting at epoch `1469694264`:
 
     ```bash
-    bm server logs /helloworld --start-time 1469694264
+    bm server logs --start-time 1469694264
     ```
 
 -   Logs will be polled and the output will be logged to your terminal:
 
     ```bash
-    bm server logs /helloworld --tail
+    bm server logs --tail
     ```
 
     **Note**: Requires a `CTRL + C` to stop the polling.
@@ -73,5 +73,5 @@ bm server logs /helloworld
 -   View only the logs that contain the string `CustomError`:
 
     ```bash
-    bm server logs /helloworld --filter CustomError
+    bm server logs --filter CustomError
     ```

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -100,7 +100,7 @@ Would create the following routes:
 
 ### Timeouts
 
--   Each route will have a default of **15 seconds** to complete before it will automatically timeout. The default for the project and overrides at the route level can be set in `.blinkmrc.json`:
+-   All route will have a default of **15 seconds** to complete before it will automatically timeout. The timeout for all routes in the project can be set in `.blinkmrc.json`:
 
     ```json
     {
@@ -109,8 +109,7 @@ Would create the following routes:
         "routes": [
           {
             "route": "/api/hello/{name}",
-            "module": "./api/hello.js",
-            "timeout": 20
+            "module": "./api/hello.js"
           },
           {
             "route": "/api/helloworld",
@@ -125,5 +124,5 @@ Would create the following routes:
 
     Route             | Module              | Timeout (seconds)
     ------------------|---------------------|------------------
-    /api/hello/{name} | ./api/hello.js      | 20
+    /api/hello/{name} | ./api/hello.js      | 10
     /api/helloworld   | ./api/helloworld.js | 10

--- a/examples/configuration/.blinkmrc.json
+++ b/examples/configuration/.blinkmrc.json
@@ -6,13 +6,11 @@
     "routes": [
       {
         "route": "/request",
-        "module": "./api/request/index.js",
-        "timeout": 5
+        "module": "./api/request/index.js"
       },
       {
         "route": "/books",
-        "module": "./api/books.js",
-        "timeout": 5
+        "module": "./api/books.js"
       },
       {
         "route": "/books/{id}",

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -10,8 +10,6 @@ import type {
 
 const path = require('path')
 
-const uniloc = require('uniloc')
-
 const handlers = require('./handlers.js')
 const readRoutes = require('./routes/read.js')
 
@@ -31,21 +29,9 @@ function getRouteConfig (
   route /* : string */
 ) /* : Promise<RouteConfiguration> */ {
   return readRoutes(cwd)
-    .then((routes) => {
-      const unilocRoutes = routes.reduce((memo, r) => {
-        memo[r.route] = `GET ${r.route.replace(/{/g, ':').replace(/}/g, '')}`
-        return memo
-      }, {})
-      const unilocRouter = uniloc(unilocRoutes)
-      const unilocRoute = unilocRouter.lookup(route, 'GET')
-
-      const routeConfig = routes.find((routeConfig) => routeConfig.route === unilocRoute.name)
-      if (!routeConfig) {
-        return Promise.reject(new Error(`Route has not been implemented: /${route}`))
-      }
-
+    .then((routeConfigs) => handlers.findRouteConfig(route, routeConfigs))
+    .then((routeConfig) => {
       routeConfig.module = path.resolve(cwd, routeConfig.module)
-      routeConfig.params = unilocRoute.options
       wipeRouteFromRequireCache(routeConfig)
       return routeConfig
     })

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -4,9 +4,13 @@
 /* ::
 import type {
   Handler,
-  BmRequest
+  BmRequest,
+  RouteConfiguration
 } from '../types.js'
 */
+
+const uniloc = require('uniloc')
+
 const BmResponse = require('../lib/bm-response.js')
 
 function executeHandler (
@@ -47,7 +51,28 @@ function getHandler (
   }
 }
 
+function findRouteConfig (
+  route /* : string */,
+  routeConfigs /* : RouteConfiguration[] */
+) /* : RouteConfiguration */ {
+  const unilocRoutes = routeConfigs.reduce((memo, r) => {
+    memo[r.route] = `GET ${r.route.replace(/{/g, ':').replace(/}/g, '')}`
+    return memo
+  }, {})
+  const unilocRouter = uniloc(unilocRoutes)
+  const unilocRoute = unilocRouter.lookup(route, 'GET')
+
+  const routeConfig = routeConfigs.find((routeConfig) => routeConfig.route === unilocRoute.name)
+  if (!routeConfig) {
+    throw new Error(`Route has not been implemented: ${route}`)
+  }
+
+  routeConfig.params = unilocRoute.options
+  return routeConfig
+}
+
 module.exports = {
+  findRouteConfig,
   executeHandler,
   getHandler
 }

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -61,6 +61,7 @@ function normaliseHapiRequest (
     body: request.payload,
     headers: request.headers,
     method: request.method,
+    route: '',
     url: urlInfo
   }
 }
@@ -92,7 +93,10 @@ function startServer (
 
       apis.getRouteConfig(cwd, route)
         .catch((err) => Promise.reject(Boom.wrap(err, 404)))
-        .then((routeConfig) => apis.getHandlerConfig(routeConfig, request.method))
+        .then((routeConfig) => {
+          request.route = routeConfig.route
+          return apis.getHandlerConfig(routeConfig, request.method)
+        })
         .then((handlerConfig) => {
           if (typeof handlerConfig.handler !== 'function') {
             reply(Boom.methodNotAllowed(`${request.method.toUpperCase()} method has not been implemented`)) // 405

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -20,6 +20,7 @@ const scope = require('./scope.js')
 const updateYamlFile = require('./utils/yaml.js').updateYamlFile
 const copyRecursive = require('./utils/copy-recursive.js')
 const validateCors = require('./cors/validate.js')
+const values = require('./values.js')
 
 const HANDLER = 'handler'
 const WRAPPER = path.join(__dirname, '..', 'dist', 'wrapper.js')
@@ -75,11 +76,10 @@ function executeSLSCommand (
 
 function getFunctionName (
   cfg /* : BlinkMRCServer */,
-  routeConfig /* : RouteConfiguration */,
   env /* : string */
 ) /* : string */ {
   // Lambdas do not allow for any characters other than alpha-numeric and dashes in function names
-  const arr = [cfg.project || '', env, routeConfig.route]
+  const arr = [cfg.project || '', env]
   const mapped = arr.map(nonAlphaNumericToDashes)
   return mapped.join('-')
 }
@@ -89,38 +89,28 @@ function registerFunctions (
   projectPath /* : string */,
   env /* : string */
 ) /* : Promise<void> */ {
-  return Promise.all([
-    readRoutes(projectPath),
-    scope.read(projectPath)
-  ])
-    .then((results) => {
-      const routeConfigs = results[0]
-      const cfg = results[1]
+  return scope.read(projectPath)
+    .then((cfg) => updateServerlessYamlFile(target, (config) => {
+      config.service = nonAlphaNumericToDashes(cfg.project || '')
+      config.provider = config.provider || {}
+      config.provider.region = cfg.region
+      config.provider.stage = env
 
-      return updateServerlessYamlFile(target, (config) => {
-        config.service = nonAlphaNumericToDashes(cfg.project || '')
-        config.provider = config.provider || {}
-        config.provider.region = cfg.region
-        config.provider.stage = env
-        config.functions = routeConfigs.reduce((functions, routeConfig, index) => {
-          // The route must not start with a leading '/'
-          const route = routeConfig.route.substr(1)
-          const functionName = getFunctionName(cfg, routeConfig, env)
-          functions[functionName] = {
-            events: [{
-              http: `ANY ${route}`
-            }],
-            handler: `${HANDLER}.handler`,
-            name: functionName,
-            description: routeConfig.route,
-            timeout: routeConfig.timeout
-          }
-          return functions
-        }, {})
+      const functionName = getFunctionName(cfg, env)
+      config.functions = {
+        [functionName]: {
+          events: [{
+            http: 'ANY {path+}'
+          }],
+          handler: `${HANDLER}.handler`,
+          name: functionName,
+          description: `Server CLI Lambda function for project: ${cfg.project || ''}`,
+          timeout: cfg.timeout || values.DEFAULT_TIMEOUT_SECONDS
+        }
+      }
 
-        return config
-      })
-    })
+      return config
+    }))
 }
 
 function registerDeploymentBucket (

--- a/scripts/wrapper.js
+++ b/scripts/wrapper.js
@@ -57,11 +57,36 @@ function handler (
     statusCode: number
   }) => void */
 ) /* : Promise<void> */ {
+  const startTime = Date.now()
   const request = normaliseLambdaRequest(event)
   const internalHeaders = {}
   internalHeaders['Content-Type'] = 'application/json'
   const finish = (statusCode, body, customHeaders) => {
     const headers = Object.assign(internalHeaders, customHeaders)
+    const endTime = Date.now()
+    const requestTime = endTime - startTime
+    console.log('BLINKM_ANALYTICS_EVENT', JSON.stringify({ // eslint-disable-line no-console
+      request: {
+        method: request.method.toUpperCase(),
+        query: request.url.query,
+        port: 443,
+        path: request.route,
+        hostName: request.url.hostname,
+        params: request.url.params,
+        protocol: request.url.protocol
+      },
+      response: {
+        statusCode: statusCode
+      },
+      requestTime: {
+        startDateTime: new Date(startTime),
+        startTimeStamp: startTime,
+        endDateTime: new Date(endTime),
+        endTimeStamp: endTime,
+        ms: requestTime,
+        s: requestTime / 1000
+      }
+    }, null, 2))
     cb(null, {
       body: JSON.stringify(body, null, 2),
       headers: wrapper.keysToLowerCase(headers),

--- a/scripts/wrapper.js
+++ b/scripts/wrapper.js
@@ -36,6 +36,7 @@ function normaliseLambdaRequest (
     body,
     headers,
     method: wrapper.normaliseMethod(event.httpMethod),
+    route: '',
     url: {
       host,
       hostname: host,

--- a/test/apis.js
+++ b/test/apis.js
@@ -99,7 +99,7 @@ test('getRouteConfig() should reject if readRoutes() throws an error', (t) => {
 
 test('getRouteConfig() should reject if route cannot be found', (t) => {
   const apis = t.context.getTestSubject()
-  return t.throws(apis.getRouteConfig(CONFIGURATION_DIR, 'missing'), 'Route has not been implemented: /missing')
+  return t.throws(apis.getRouteConfig(CONFIGURATION_DIR, 'missing'), 'Route has not been implemented: missing')
 })
 
 test('getRouteConfig() should find correct route and return route params', (t) => {

--- a/test/fixtures/serverless/examples/configuration.yml
+++ b/test/fixtures/serverless/examples/configuration.yml
@@ -14,33 +14,12 @@ provider:
       - abc
       - def
 functions:
-  bm-example-api-blinkm-io-prod--request:
+  bm-example-api-blinkm-io-prod:
     events:
-      - http: ANY request
+      - http: ANY {path+}
     handler: handler.handler
-    name: bm-example-api-blinkm-io-prod--request
-    description: /request
-    timeout: 5
-  bm-example-api-blinkm-io-prod--books:
-    events:
-      - http: ANY books
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-prod--books
-    description: /books
-    timeout: 5
-  bm-example-api-blinkm-io-prod--books--id-:
-    events:
-      - http: 'ANY books/{id}'
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-prod--books--id-
-    description: '/books/{id}'
-    timeout: 15
-  bm-example-api-blinkm-io-prod--books--id--chapters--chapterNo-:
-    events:
-      - http: 'ANY books/{id}/chapters/{chapterNo}'
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-prod--books--id--chapters--chapterNo-
-    description: '/books/{id}/chapters/{chapterNo}'
+    name: bm-example-api-blinkm-io-prod
+    description: 'Server CLI Lambda function for project: bm-example.api.blinkm.io'
     timeout: 15
 resources:
   Resources:
@@ -67,3 +46,4 @@ resources:
             - ResponseParameters:
                 method.response.header.Content-Type: integration.response.header.Content-Type
               StatusCode: 200
+

--- a/test/fixtures/serverless/examples/directory.yml
+++ b/test/fixtures/serverless/examples/directory.yml
@@ -5,48 +5,13 @@ provider:
   region: ap-southeast-2
   stage: test
 functions:
-  bm-example-api-blinkm-io-test--boom:
+  bm-example-api-blinkm-io-test:
     events:
-      - http: ANY boom
+      - http: ANY {path+}
     handler: handler.handler
-    name: bm-example-api-blinkm-io-test--boom
-    description: /boom
-    timeout: 15
-  bm-example-api-blinkm-io-test--helloworld:
-    events:
-      - http: ANY helloworld
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-test--helloworld
-    description: /helloworld
-    timeout: 15
-  bm-example-api-blinkm-io-test--methods:
-    events:
-      - http: ANY methods
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-test--methods
-    description: /methods
-    timeout: 15
-  bm-example-api-blinkm-io-test--promise:
-    events:
-      - http: ANY promise
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-test--promise
-    description: /promise
-    timeout: 15
-  bm-example-api-blinkm-io-test--request:
-    events:
-      - http: ANY request
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-test--request
-    description: /request
-    timeout: 15
-  bm-example-api-blinkm-io-test--response:
-    events:
-      - http: ANY response
-    handler: handler.handler
-    name: bm-example-api-blinkm-io-test--response
-    description: /response
-    timeout: 15
+    name: bm-example-api-blinkm-io-test
+    description: 'Server CLI Lambda function for project: bm-example.api.blinkm.io'
+    timeout: 5
 resources:
   Resources:
     ProxyMethod:

--- a/test/logs.js
+++ b/test/logs.js
@@ -21,14 +21,6 @@ const CLI_OPTIONS = {
   blinkMobileIdentity: new BlinkMobileIdentityMock()
 }
 
-test('should reject if a route is not specified', (t) => {
-  const logs = require('../commands/logs.js')
-  return t.throws(
-    logs([], createCliFlags(), console, CLI_OPTIONS),
-    'Must specify a route. E.g. bm server logs /route'
-  )
-})
-
 test('should call "serverless logs" with correct arguments and options', (t) => {
   t.plan(5)
   const logs = proxyquire('../commands/logs.js', {
@@ -37,7 +29,7 @@ test('should call "serverless logs" with correct arguments and options', (t) => 
         t.deepEqual(args, [
           'logs',
           '--function',
-          'bm-example-api-blinkm-io-prod--request',
+          'bm-example-api-blinkm-io-prod',
           '--region',
           'ap-southeast-2',
           '--stage',
@@ -56,7 +48,7 @@ test('should call "serverless logs" with correct arguments and options', (t) => 
       }
     }
   })
-  return logs(['/request'], createCliFlags({
+  return logs([], createCliFlags({
     cwd: DIRECTORY_DIR,
     env: 'prod',
     tail: true,
@@ -72,7 +64,7 @@ test('should reject if "serverless logs" fails', (t) => {
     }
   })
   return t.throws(
-    logs(['/request'], createCliFlags({
+    logs([], createCliFlags({
       cwd: DIRECTORY_DIR,
       env: 'prod'
     }), console, CLI_OPTIONS),

--- a/test/scripts/wrapper.js
+++ b/test/scripts/wrapper.js
@@ -108,7 +108,7 @@ test('handler() should return correct boom response', (t) => {
   })
 })
 
-test('handler() should return 500 status code if route is not found', (t) => {
+test('handler() should return 404 status code if route is not found', (t) => {
   t.plan(2)
   const route = '/missing'
   const lib = t.context.getTestSubject()

--- a/test/scripts/wrapper.js
+++ b/test/scripts/wrapper.js
@@ -57,6 +57,7 @@ test('normaliseLambdaRequest()', (t) => {
       host: 'this is the host'
     },
     method: 'get',
+    route: '',
     url: {
       host: 'this is the host',
       hostname: 'this is the host',

--- a/test/scripts/wrapper.js
+++ b/test/scripts/wrapper.js
@@ -1,9 +1,12 @@
 'use strict'
 
+const path = require('path')
+
 const test = require('ava')
 const proxyquire = require('proxyquire')
 
 const TEST_SUBJECT = '../../scripts/wrapper.js'
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'scripts', 'bm-server.json')
 
 const CORS = {
   origins: [
@@ -68,7 +71,7 @@ test('normaliseLambdaRequest()', (t) => {
 test('handler() should return correct response', (t) => {
   t.plan(2)
   const lib = t.context.getTestSubject()
-  const event = Object.assign({}, EVENT, {resource: '/response'})
+  const event = Object.assign({}, EVENT, {path: '/response'})
 
   return lib.handler(event, null, (err, result) => {
     t.falsy(err)
@@ -86,7 +89,7 @@ test('handler() should return correct response', (t) => {
 test('handler() should return correct boom response', (t) => {
   t.plan(2)
   const lib = t.context.getTestSubject()
-  const event = Object.assign({}, EVENT, {resource: '/boom'})
+  const event = Object.assign({}, EVENT, {path: '/boom'})
 
   return lib.handler(event, null, (err, result) => {
     t.falsy(err)
@@ -106,21 +109,22 @@ test('handler() should return correct boom response', (t) => {
 
 test('handler() should return 500 status code if route is not found', (t) => {
   t.plan(2)
+  const route = '/missing'
   const lib = t.context.getTestSubject()
-  const event = Object.assign({}, EVENT, {resource: '/missing'})
+  const event = Object.assign({}, EVENT, {path: route})
 
   return lib.handler(event, null, (err, result) => {
     t.falsy(err)
     t.deepEqual(result, {
       body: JSON.stringify({
-        error: 'Internal Server Error',
-        message: 'An internal server error occurred',
-        statusCode: 500
+        error: 'Not Found',
+        message: `Route has not been implemented: ${route}`,
+        statusCode: 404
       }, null, 2),
       headers: {
         'content-type': 'application/json'
       },
-      statusCode: 500
+      statusCode: 404
     })
   })
 })
@@ -133,7 +137,7 @@ test.serial('handler() should return 500 status code if current working director
     throw new Error('test chdir error')
   }
   const lib = t.context.getTestSubject()
-  const event = Object.assign({}, EVENT, {resource: '/response'})
+  const event = Object.assign({}, EVENT, {path: '/response'})
 
   return lib.handler(event, null, (err, result) => {
     t.falsy(err)
@@ -157,7 +161,7 @@ test('handler() should return 405 status code if method is not found', (t) => {
   const lib = t.context.getTestSubject()
   const event = Object.assign({}, EVENT, {
     httpMethod: 'POST',
-    resource: '/response'
+    path: '/response'
   })
 
   return lib.handler(event, null, (err, result) => {
@@ -181,7 +185,7 @@ test('handler() should return 405 for options requests with no CORS', (t) => {
   const lib = t.context.getTestSubject()
   const event = Object.assign({}, EVENT, {
     httpMethod: 'OPTIONS',
-    resource: '/response',
+    path: '/response',
     headers: {
       host: 'host',
       origin: 'valid'
@@ -207,13 +211,13 @@ test('handler() should return 405 for options requests with no CORS', (t) => {
 test('handler() should return 200 for options requests with CORS and valid origin', (t) => {
   t.plan(2)
   const lib = t.context.getTestSubject({
-    'load-json-file': () => Promise.resolve({
+    [CONFIG_PATH]: {
       cors: CORS,
       routes: [{
         module: './project/test-response.js',
         route: '/response'
       }]
-    })
+    }
   })
   const event = Object.assign({}, EVENT, {
     headers: {
@@ -222,7 +226,7 @@ test('handler() should return 200 for options requests with CORS and valid origi
       'Access-Control-Request-Method': 'GET'
     },
     httpMethod: 'OPTIONS',
-    resource: '/response'
+    path: '/response'
   })
 
   return lib.handler(event, null, (err, result) => {
@@ -246,9 +250,9 @@ test('handler() should return 200 for options requests with CORS and valid origi
 test('handler() should return 200 for requests with CORS and invalid origin', (t) => {
   t.plan(2)
   const lib = t.context.getTestSubject({
-    'load-json-file': () => Promise.resolve({
+    [CONFIG_PATH]: {
       cors: Object.assign({}, CORS, {origins: ['invalid']})
-    })
+    }
   })
   const event = Object.assign({}, EVENT, {
     headers: {
@@ -256,7 +260,7 @@ test('handler() should return 200 for requests with CORS and invalid origin', (t
       origin: 'valid'
     },
     httpMethod: 'OPTIONS',
-    resource: '/response'
+    path: '/response'
   })
 
   return lib.handler(event, null, (err, result) => {

--- a/types.js
+++ b/types.js
@@ -28,6 +28,7 @@ export type BmRequest = {
   body: any,
   headers: Headers,
   method: string,
+  route: string,
   url: {
     host: string,
     hostname: string,


### PR DESCRIPTION

### Added

-   SC-71: `route` property to `request` argument passed to handlers. Will contain the original `route` property.
-   SC-71: analytics log message to wrapper to allow for metrics and analysis on routes

### Changed

-   SC-71: `bm server serverless` now creates one set of AWS resources (Lambda, API Gateway Endpoint and Log Group) for all routes in a project instead of one set for each route.

### Removed

-   SC-71: `/route` input from `bm server logs /route`. Logs will now be retrieved for all routes in the project.
-   SC-71: timeout override at the route level. All routes will now share the same timeout.

### Code Review Notes

-    **Contains Breaking Changes**
-   Probably easier to code review these one at a time.