### PR TITLE
SC-64 # Latest version of Serverless and node6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Changed
 
--   SC-63: Bumped minimum supported version Node version to `>=6`
+-   SC-64: Bumped minimum supported version Node version to `>=6`
+-   SC-64: Execution environment from Node4.3 to Node6.10
 -   SC-71: `bm server serverless` now creates one set of AWS resources (Lambda, API Gateway Endpoint and Log Group) for all routes in a project instead of one set for each route.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+-   SC-63: Bumped minimum supported version Node version to `>=6`
 -   SC-71: `bm server serverless` now creates one set of AWS resources (Lambda, API Gateway Endpoint and Log Group) for all routes in a project instead of one set for each route.
 
 ### Removed

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,7 @@
 -   [Root Route](./roo-route.md)
 
 -   [Suggestions](./suggestions.md)
+
+## Breaking Changes
+
+-   [Migrating to `v2.x.x`](./migrate-to-v2.x.md)

--- a/docs/migrate-to-v2.x.md
+++ b/docs/migrate-to-v2.x.md
@@ -1,0 +1,89 @@
+# Migrating to `v2.x.x` from `v1.x.x`
+
+Version `2.x.x` contained a number of breaking changes and will need to be handled before using the Server CLI to deploy server-side HTTPS endpoints again.
+
+## Node Version Support
+
+### `v1.x.x`
+
+Only Node `4.3.x` was supported in the execution environment.
+
+### `v2.x.x`
+
+NodeJS `6.10.x` will now be the only version of node supported in the execution environment.
+
+See [Breaking changes between v4 LTS and v6 LTS](https://github.com/nodejs/node/wiki/Breaking-changes-between-v4-LTS-and-v6-LTS) for more information on breaking changes.
+
+## Route Timeouts
+
+### `v1.x.x`
+
+A single timeout could be set at the project level and overridden on each individual route if required:
+
+```json
+{
+  "server": {
+    "project": "bm-example.api.blinkm.io",
+    "region": "ap-southeast-2",
+    "cors": true,
+    "timeout": 10,
+    "routes": [
+      {
+        "route": "/helloworld",
+        "module": "./request/index.js",
+        "timeout": 5
+      },
+      {
+        "route": "/test",
+        "module": "./test/index.js"
+      }
+    ]
+  }
+}
+```
+
+### `v2.x.x`
+
+Timeouts can now only be set at the project level. **There is no longer an option to override the project level value (currently defaulting to 15 seconds is unset)**. We recommend setting the project level timeout to the maximum timeout required for each route:
+
+```json
+{
+  "server": {
+    "project": "bm-example.api.blinkm.io",
+    "region": "ap-southeast-2",
+    "cors": true,
+    "timeout": 10,
+    "routes": [
+      {
+        "route": "/helloworld",
+        "module": "./request/index.js"
+      },
+      {
+        "route": "/test",
+        "module": "./test/index.js"
+      }
+    ]
+  }
+}
+```
+
+## Viewing Logs
+
+### `v1.x.x`
+
+Logs could only be viewed for a single route at a time:
+
+```
+bm server logs /helloworld
+```
+
+### `v2.x.x`
+
+Logs can now **only** be viewed for the entire project:
+
+```
+bm server logs
+```
+
+All existing flags still exist and there functionaltity has not changed.
+

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "object-merge": "2.5.1",
     "pify": "3.0.0",
     "request": "2.81.0",
-    "serverless": "1.9.0",
+    "serverless": "1.14.0",
     "temp": "0.8.3",
     "uniloc": "0.3.0",
     "update-notifier": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test": "test"
   },
   "engines": {
-    "node": ">=4",
+    "node": ">=6",
     "npm": ">=3"
   },
   "files": [

--- a/test/fixtures/serverless/examples/configuration.yml
+++ b/test/fixtures/serverless/examples/configuration.yml
@@ -1,7 +1,7 @@
 service: bm-example-api-blinkm-io
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   region: ap-southeast-2
   stage: prod
   deploymentBucket: deployment-bucket

--- a/test/fixtures/serverless/examples/directory.yml
+++ b/test/fixtures/serverless/examples/directory.yml
@@ -1,7 +1,7 @@
 service: bm-example-api-blinkm-io
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   region: ap-southeast-2
   stage: test
 functions:


### PR DESCRIPTION

### Changed

-   SC-64: Bumped minimum supported version Node version to `>=6`
-   SC-64: Execution environment from Node4.3 to Node6.10